### PR TITLE
Fee changes

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -803,6 +803,7 @@ bool CWalletDB::LoadWallet(CWallet* pwallet)
                 if (strKey == "fGenerateBitcoins")  ssValue >> fGenerateBitcoins;
 #endif
                 if (strKey == "nTransactionFee")    ssValue >> nTransactionFee;
+                if (strKey == "nMinimumInputValue") ssValue >> nMinimumInputValue;
                 if (strKey == "fLimitProcessors")   ssValue >> fLimitProcessors;
                 if (strKey == "nLimitProcessors")   ssValue >> nLimitProcessors;
                 if (strKey == "fMinimizeToTray")    ssValue >> fMinimizeToTray;
@@ -821,6 +822,7 @@ bool CWalletDB::LoadWallet(CWallet* pwallet)
     printf("nFileVersion = %d\n", nFileVersion);
     printf("fGenerateBitcoins = %d\n", fGenerateBitcoins);
     printf("nTransactionFee = %"PRI64d"\n", nTransactionFee);
+    printf("nMinimumInputValue = %"PRI64d"\n", nMinimumInputValue);
     printf("fMinimizeToTray = %d\n", fMinimizeToTray);
     printf("fMinimizeOnClose = %d\n", fMinimizeOnClose);
     printf("fUseProxy = %d\n", fUseProxy);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -186,6 +186,7 @@ bool AppInit2(int argc, char* argv[])
 #endif
 #endif
             "  -paytxfee=<amt>  \t  "   + _("Fee per KB to add to transactions you send\n") +
+            "  -mininput=<amt>  \t  "   + _("When creating transactions, ignore inputs with value less than this (default: 0.0001)\n") +
 #ifdef GUI
             "  -server          \t\t  " + _("Accept command line and JSON-RPC commands\n") +
 #endif
@@ -510,6 +511,15 @@ bool AppInit2(int argc, char* argv[])
         }
         if (nTransactionFee > 0.25 * COIN)
             wxMessageBox(_("Warning: -paytxfee is set very high.  This is the transaction fee you will pay if you send a transaction."), "Bitcoin", wxOK | wxICON_EXCLAMATION);
+    }
+
+    if (mapArgs.count("-mininput"))
+    {
+        if (!ParseMoney(mapArgs["-mininput"], nMinimumInputValue))
+        {
+            wxMessageBox(_("Invalid amount for -mininput=<amount>"), "Litecoin");
+            return false;
+        }
     }
 
     if (fHaveUPnP)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,6 +56,7 @@ int64 nHPSTimerStart;
 // Settings
 int fGenerateBitcoins = false;
 int64 nTransactionFee = 0;
+int64 nMinimumInputValue = CENT / 100;
 int fLimitProcessors = false;
 int nLimitProcessors = 1;
 int fMinimizeToTray = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1385,7 +1385,7 @@ bool CBlock::AcceptBlock()
     return true;
 }
 
-bool static ProcessBlock(CNode* pfrom, CBlock* pblock)
+bool ProcessBlock(CNode* pfrom, CBlock* pblock)
 {
     // Check for duplicate
     uint256 hash = pblock->GetHash();

--- a/src/main.h
+++ b/src/main.h
@@ -36,7 +36,7 @@ static const unsigned int MAX_BLOCK_SIZE_GEN = MAX_BLOCK_SIZE/2;
 static const int MAX_BLOCK_SIGOPS = MAX_BLOCK_SIZE/50;
 static const int64 COIN = 100000000;
 static const int64 CENT = 1000000;
-static const int64 MIN_TX_FEE = 50000;
+static const int64 MIN_TX_FEE = 500000;
 static const int64 MIN_RELAY_TX_FEE = 10000;
 static const int64 MAX_MONEY = 21000000 * COIN;
 inline bool MoneyRange(int64 nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }

--- a/src/main.h
+++ b/src/main.h
@@ -558,7 +558,7 @@ public:
         if (nMinFee < nBaseFee)
             BOOST_FOREACH(const CTxOut& txout, vout)
                 if (txout.nValue < CENT)
-                    nMinFee = nBaseFee;
+                    nMinFee += nBaseFee;
 
         // Raise the price as the block approaches full
         if (nBlockSize != 1 && nNewBlockSize >= MAX_BLOCK_SIZE_GEN/2)

--- a/src/main.h
+++ b/src/main.h
@@ -542,9 +542,8 @@ public:
         {
             if (nBlockSize == 1)
             {
-                // Transactions under 10K are free
-                // (about 4500bc if made of 50bc inputs)
-                if (nBytes < 10000)
+                // Transactions under 1K are free
+                if (nBytes < 1000)
                     nMinFee = 0;
             }
             else

--- a/src/main.h
+++ b/src/main.h
@@ -549,7 +549,7 @@ public:
             else
             {
                 // Free transaction area
-                if (nNewBlockSize < 27000)
+                if (nNewBlockSize < 9000)
                     nMinFee = 0;
             }
         }

--- a/src/main.h
+++ b/src/main.h
@@ -72,6 +72,7 @@ extern std::set<CWallet*> setpwalletRegistered;
 // Settings
 extern int fGenerateBitcoins;
 extern int64 nTransactionFee;
+extern int64 nMinimumInputValue;
 extern int fLimitProcessors;
 extern int nLimitProcessors;
 extern int fMinimizeToTray;

--- a/src/main.h
+++ b/src/main.h
@@ -88,6 +88,7 @@ class CTxIndex;
 
 void RegisterWallet(CWallet* pwalletIn);
 void UnregisterWallet(CWallet* pwalletIn);
+bool ProcessBlock(CNode* pfrom, CBlock* pblock);
 bool CheckDiskSpace(uint64 nAdditionalBytes=0);
 FILE* OpenBlockFile(unsigned int nFile, unsigned int nBlockPos, const char* pszMode="rb");
 FILE* AppendBlockFile(unsigned int& nFileRet);

--- a/src/main.h
+++ b/src/main.h
@@ -561,7 +561,7 @@ public:
                     nMinFee += nBaseFee;
 
         // Raise the price as the block approaches full
-        if (nBlockSize != 1 && nNewBlockSize >= MAX_BLOCK_SIZE_GEN/2)
+        if (nBlockSize != 1 && nNewBlockSize >= MAX_BLOCK_SIZE_GEN/4)
         {
             if (nNewBlockSize >= MAX_BLOCK_SIZE_GEN)
                 return MAX_MONEY;

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -453,6 +453,7 @@ Value getinfo(const Array& params, bool fHelp)
     obj.push_back(Pair("testnet",       fTestNet));
     obj.push_back(Pair("keypoololdest", (boost::int64_t)pwalletMain->GetOldestKeyPoolTime()));
     obj.push_back(Pair("paytxfee",      ValueFromAmount(nTransactionFee)));
+    obj.push_back(Pair("mininput",      ValueFromAmount(nMinimumInputValue)));
     obj.push_back(Pair("errors",        GetWarnings("statusbar")));
     return obj;
 }
@@ -648,6 +649,22 @@ Value settxfee(const Array& params, bool fHelp)
         nAmount = AmountFromValue(params[0]);        // rejects 0.0 amounts
 
     nTransactionFee = nAmount;
+    return true;
+}
+
+Value setmininput(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() < 1 || params.size() > 1)
+        throw runtime_error(
+            "setmininput <amount>\n"
+            "<amount> is a real and is rounded to the nearest 0.00000001");
+
+    // Amount
+    int64 nAmount = 0;
+    if (params[0].get_real() != 0.0)
+        nAmount = AmountFromValue(params[0]);        // rejects 0.0 amounts
+
+    nMinimumInputValue = nAmount;
     return true;
 }
 
@@ -2012,6 +2029,7 @@ pair<string, rpcfn_type> pCallTable[] =
     make_pair("listaccounts",          &listaccounts),
     make_pair("settxfee",              &settxfee),
     make_pair("getmemorypool",         &getmemorypool),
+    make_pair("setmininput",           &setmininput),
 };
 map<string, rpcfn_type> mapCallTable(pCallTable, pCallTable + sizeof(pCallTable)/sizeof(pCallTable[0]));
 
@@ -2656,6 +2674,7 @@ int CommandLineRPC(int argc, char *argv[])
         if (strMethod == "sendtoaddress"          && n > 1) ConvertTo<double>(params[1]);
         if (strMethod == "settxfee"               && n > 0) ConvertTo<double>(params[0]);
         if (strMethod == "getamountreceived"      && n > 1) ConvertTo<boost::int64_t>(params[1]); // deprecated
+        if (strMethod == "setmininput"            && n > 0) ConvertTo<double>(params[0]);
         if (strMethod == "getreceivedbyaddress"   && n > 1) ConvertTo<boost::int64_t>(params[1]);
         if (strMethod == "getreceivedbyaccount"   && n > 1) ConvertTo<boost::int64_t>(params[1]);
         if (strMethod == "getreceivedbylabel"     && n > 1) ConvertTo<boost::int64_t>(params[1]); // deprecated

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -621,7 +621,9 @@ bool CWallet::SelectCoinsMinConf(int64 nTargetValue, int nConfMine, int nConfThe
 
                 int64 n = pcoin->vout[i].nValue;
 
-                if (n <= 0)
+                // If output is less than minimum value, then don't include transaction.
+                // This is to help deal with dust spam clogging up create transactions.
+                if (n <= 0 || n < nMinimumInputValue)
                     continue;
 
                 pair<int64,pair<const CWalletTx*,unsigned int> > coin = make_pair(n,make_pair(pcoin,i));

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -103,7 +103,9 @@ public:
     bool IsMine(const CTransaction& tx) const
     {
         BOOST_FOREACH(const CTxOut& txout, tx.vout)
-            if (IsMine(txout))
+            // If output is less than minimum value, then don't include transaction.
+            // This is to help deal with dust spam bloating the wallet.
+            if (IsMine(txout) && txout.nValue >= nMinimumInputValue)
                 return true;
         if (hooks->IsMine(tx))
             return true;


### PR DESCRIPTION
For discussion to cut down on the current spam transaction problem. This contains patches for the following:
- Changes the minimum transaction fee from 0.0005 to 0.005. Maybe this should even be higher? Namecoins are cheap.
- Changes the threshold for when fees increase due to the block becoming full. the current spam attack is set just under the current threshold.
- Reduces the free transaction area from 27,000 to 9,000.
- Increases the minimum fee for dust transactions. Currently the fee is set to a constant no matter how many dust outputs there are. This sets it based on the number of dust outputs. Maybe this should penalize even more?

Thoughts?
