### PR TITLE
Add some basic id/ support for name configuration tab

### DIFF
--- a/src/qt/configurenamedialog.h
+++ b/src/qt/configurenamedialog.h
@@ -34,6 +34,9 @@ public slots:
     void on_nsFingerprintEdit_textChanged()                   { if (initialized) SetDNS(); }
     void on_ipEdit_textChanged(const QString &text)           { if (initialized) SetIP();  }
     void on_ipFingerprintEdit_textChanged()                   { if (initialized) SetIP(); }
+    void on_idNameEdit_textChanged()                          { if (initialized) SetID(); }
+    void on_idEmailEdit_textChanged()                         { if (initialized) SetID(); }
+    void on_idBitmessageEdit_textChanged()                    { if (initialized) SetID(); }
     void on_dataEdit_textChanged(const QString &text);
 
 private:
@@ -46,6 +49,7 @@ private:
 
     void SetDNS();
     void SetIP();
+    void SetID();
 };
 
 #endif // CONFIGURENAMEDIALOG_H

--- a/src/qt/forms/configurenamedialog.ui
+++ b/src/qt/forms/configurenamedialog.ui
@@ -72,7 +72,7 @@
      <item row="4" column="0">
       <widget class="QLabel" name="label">
        <property name="text">
-        <string>&amp;Data:</string>
+        <string>Data:</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -269,6 +269,64 @@ ns0.xname.org
             </size>
            </property>
           </spacer>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="tab_id">
+        <attribute name="title">
+         <string>I&amp;dentity Configuration</string>
+        </attribute>
+        <layout class="QFormLayout" name="formLayout_4">
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_11">
+           <property name="text">
+            <string>&amp;Real name:</string>
+           </property>
+           <property name="buddy">
+            <cstring>nsTranslateEdit</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLineEdit" name="nameEdit">
+           <property name="toolTip">
+            <string>Real name or pseudonym</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_12">
+           <property name="text">
+            <string>&amp;Email address:</string>
+           </property>
+           <property name="buddy">
+            <cstring>nsTranslateEdit</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLineEdit" name="emailEdit">
+           <property name="toolTip">
+            <string>Email address</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_13">
+           <property name="text">
+            <string>Bit&amp;message:</string>
+           </property>
+           <property name="buddy">
+            <cstring>nsTranslateEdit</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QLineEdit" name="bitmessageEdit">
+           <property name="toolTip">
+            <string>Bitmessage address</string>
+           </property>
+          </widget>
          </item>
         </layout>
        </widget>

--- a/src/qt/forms/configurenamedialog.ui
+++ b/src/qt/forms/configurenamedialog.ui
@@ -288,7 +288,7 @@ ns0.xname.org
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="QLineEdit" name="nameEdit">
+          <widget class="QLineEdit" name="idNameEdit">
            <property name="toolTip">
             <string>Real name or pseudonym</string>
            </property>
@@ -305,7 +305,7 @@ ns0.xname.org
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="QLineEdit" name="emailEdit">
+          <widget class="QLineEdit" name="idEmailEdit">
            <property name="toolTip">
             <string>Email address</string>
            </property>
@@ -322,7 +322,7 @@ ns0.xname.org
           </widget>
          </item>
          <item row="2" column="1">
-          <widget class="QLineEdit" name="bitmessageEdit">
+          <widget class="QLineEdit" name="idBitmessageEdit">
            <property name="toolTip">
             <string>Bitmessage address</string>
            </property>


### PR DESCRIPTION
This implements first support for id/ names in the "configure names" dialog (in particular, the fields "name", "email" and "bitmessage").  More fields can be added easily, of course, but this is already a useful start (for instance, to point Bitmessage users to who want to associate their address with a name).
