### PR TITLE
Free some memory properly on shutdown.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,7 @@ CCriticalSection cs_mapTransactions;
 unsigned int nTransactionsUpdated = 0;
 map<COutPoint, CInPoint> mapNextTx;
 
-map<uint256, CBlockIndex*> mapBlockIndex;
+CMapBlockIndex mapBlockIndex;
 uint256 hashGenesisBlock("0x000000000062b72c5e2ceb45fbc8587e807c155b0da735e6483dfba2f0a9c770");
 CBigNum bnProofOfWorkLimit(~uint256(0) >> 32);
 const int nInitialBlockThreshold = 120; // Regard blocks up until N-threshold as "initial download"
@@ -3461,4 +3461,11 @@ std::string CBlockIndex::ToString() const
             GetBlockHash().ToString().substr(0,20).c_str(),
             (auxpow.get() != NULL) ? auxpow->GetParentBlockHash().ToString().substr(0,20).c_str() : "-"
             );
+}
+
+CMapBlockIndex::~CMapBlockIndex ()
+{
+    printf ("Freeing %d entries in CMapBlockIndex...\n", size ());
+    for (iterator i = begin (); i != end (); ++i)
+        delete i->second;
 }

--- a/src/main.h
+++ b/src/main.h
@@ -21,6 +21,7 @@
 
 class CBlock;
 class CBlockIndex;
+class CMapBlockIndex;
 class CWalletTx;
 class CWallet;
 class CKeyItem;
@@ -59,7 +60,7 @@ static const int fHaveUPnP = false;
 
 
 extern CCriticalSection cs_main;
-extern std::map<uint256, CBlockIndex*> mapBlockIndex;
+extern CMapBlockIndex mapBlockIndex;
 extern uint256 hashGenesisBlock;
 extern CBigNum bnProofOfWorkLimit;
 extern CBlockIndex* pindexGenesisBlock;
@@ -1296,6 +1297,23 @@ public:
     {
         printf("%s\n", ToString().c_str());
     }
+};
+
+
+
+
+
+/* Wrapper around std::map<uint256, CBlockIndex*> to ensure that the blocks
+   are freed properly.  While the global map is only freed at program
+   shutdown, this is useful to prevent false positives when looking
+   for memory leaks.  */
+class CMapBlockIndex : public std::map<uint256, CBlockIndex*>
+{
+
+public:
+
+    ~CMapBlockIndex ();
+
 };
 
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -54,7 +54,7 @@ uint64 nLocalHostNonce = 0;
 array<int, 10> vnThreadsRunning;
 SOCKET hListenSocket = INVALID_SOCKET;
 
-vector<CNode*> vNodes;
+CNodeList vNodes(true);
 CCriticalSection cs_vNodes;
 map<vector<unsigned char>, CAddress> mapAddresses;
 CCriticalSection cs_mapAddresses;
@@ -85,6 +85,29 @@ void CNode::PushGetBlocks(CBlockIndex* pindexBegin, uint256 hashEnd)
     hashLastGetBlocksEnd = hashEnd;
 
     PushMessage("getblocks", CBlockLocator(pindexBegin), hashEnd);
+}
+
+CNodeList::~CNodeList ()
+{
+    printf ("Freeing %d nodes in CNodeList %p...\n", size(), this);
+    while (!empty ())
+    {
+        CNode* pnode = back ();
+        pop_back ();
+
+        if (fRefCounts)
+            pnode->Release ();
+
+        // Wait until the node is no longer used.
+        while (pnode->GetRefCount () > 0)
+            Sleep (10);
+
+        CRITICAL_BLOCK(pnode->cs_vSend)
+        CRITICAL_BLOCK(pnode->cs_vRecv)
+        CRITICAL_BLOCK(pnode->cs_mapRequests)
+        CRITICAL_BLOCK(pnode->cs_inventory)
+            delete pnode;
+    }
 }
 
 
@@ -749,31 +772,8 @@ void ThreadSocketHandler(void* parg)
 void ThreadSocketHandler2(void* parg)
 {
     printf("ThreadSocketHandler started\n");
+    CNodeList vNodesDisconnected(false);
     int nPrevNodeCount = 0;
-
-    class CleanupDisconnectedQueue : public list<CNode*>
-    {
-    public:
-        ~CleanupDisconnectedQueue ()
-        {
-            printf ("Freeing %d disconnected nodes...\n", size());
-            while (!empty ())
-            {
-                CNode* pnode = front ();
-                pop_front ();
-
-                // Wait until the node is no longer used.
-                while (pnode->GetRefCount() > 0)
-                    Sleep(10);
-
-                CRITICAL_BLOCK(pnode->cs_vSend)
-                CRITICAL_BLOCK(pnode->cs_vRecv)
-                CRITICAL_BLOCK(pnode->cs_mapRequests)
-                CRITICAL_BLOCK(pnode->cs_inventory)
-                    delete pnode;
-            }
-        }
-    } vNodesDisconnected;
 
     loop
     {
@@ -790,7 +790,7 @@ void ThreadSocketHandler2(void* parg)
                     (pnode->GetRefCount() <= 0 && pnode->vRecv.empty() && pnode->vSend.empty()))
                 {
                     // remove from vNodes
-                    vNodes.erase(remove(vNodes.begin(), vNodes.end(), pnode), vNodes.end());
+                    vNodes.remove(pnode);
 
                     // close socket and cleanup
                     pnode->CloseSocketDisconnect();
@@ -798,14 +798,13 @@ void ThreadSocketHandler2(void* parg)
 
                     // hold in disconnected pool until all refs are released
                     pnode->nReleaseTime = max(pnode->nReleaseTime, GetTime() + 15 * 60);
-                    if (pnode->fNetworkNode || pnode->fInbound)
-                        pnode->Release();
+                    pnode->Release();
                     vNodesDisconnected.push_back(pnode);
                 }
             }
 
             // Delete disconnected nodes
-            list<CNode*> vNodesDisconnectedCopy = vNodesDisconnected;
+            vector<CNode*> vNodesDisconnectedCopy = vNodesDisconnected;
             BOOST_FOREACH(CNode* pnode, vNodesDisconnectedCopy)
             {
                 // wait until threads are done using it
@@ -1744,10 +1743,6 @@ public:
     }
     ~CNetCleanup()
     {
-        // Close sockets
-        BOOST_FOREACH(CNode* pnode, vNodes)
-            if (pnode->hSocket != INVALID_SOCKET)
-                closesocket(pnode->hSocket);
         if (hListenSocket != INVALID_SOCKET)
             if (closesocket(hListenSocket) == SOCKET_ERROR)
                 printf("closesocket(hListenSocket) failed with error %d\n", WSAGetLastError());

--- a/src/runValgrind.sh
+++ b/src/runValgrind.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+valgrind --leak-check=full ./namecoind 2>&1 | tee valgrind.log


### PR DESCRIPTION
This patch implements proper freeing of memory held in global STL containers.  While this only affects program shutdown anyway, I believe that it is cleaner to do it than to simply let the memory get lost, and it also prevents false positives when checking for memory leaks with valgrind.  With this patch applied, it shows no "definitely lost" memory any more.
