### PR TITLE
Remove superfluous check.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1093,9 +1093,6 @@ bool CTransaction::ConnectInputs(CTxDB& txdb, map<uint256, CTxIndex>& mapTestPoo
         if (!hooks->ConnectInputs(txdb, mapTestPool, *this, vTxPrev, vTxindex, pindexBlock, posThisTx, fBlock, fMiner))
             return false;
 
-        if (nValueIn < GetValueOut())
-            return error("ConnectInputs() : %s value in < value out", GetHash().ToString().substr(0,10).c_str());
-
         // Tally transaction fees
         int64 nTxFee = nValueIn - GetValueOut();
         if (nTxFee < 0)


### PR DESCRIPTION
Remove a superfluous check for nValueIn > nValueOut in checking
transacitons.  The same is done right in the next line where it is
verified that transaction fees are non-negative.
