### PR TITLE
Extended transaction decoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
-src/*.exe
 *.pyc
-src/bitcoin
-src/bitcoind
 .*.swp
 *.*~*
+qrc_bitcoin.cpp
+namecoin-qt
+namecoin-qt.exe
 src/namecoind
+src/namecoind.exe
+build
+Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,12 @@
 *.pyc
 .*.swp
 *.*~*
-qrc_bitcoin.cpp
 namecoin-qt
 namecoin-qt.exe
 src/namecoind
 src/namecoind.exe
+
+# Stuff created by the Qt build system.
+qrc_bitcoin.cpp
 build
-Makefile
+/Makefile

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -2620,6 +2620,10 @@ void ScriptPubKeyToJSON(const CScript& scriptPubKey, Object& out)
         return;
     }
 
+    /* Note:  ExtractDestination handles both pubkey hash and pubkey,
+       but the code below prints pubkeyhash as type in both cases.  That
+       is not so big a deal, presumably.  */
+
     out.push_back(Pair("reqSigs", nRequired));
     out.push_back(Pair("type", "pubkeyhash" /*GetTxnOutputType(type)*/ ));
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -736,7 +736,7 @@ uint256 static GetOrphanRoot(const CBlock* pblock)
     return pblock->GetHash();
 }
 
-int64 static GetBlockValue(int nHeight, int64 nFees)
+int64 GetBlockValue(int nHeight, int64 nFees)
 {
     int64 nSubsidy = 50 * COIN;
 

--- a/src/main.h
+++ b/src/main.h
@@ -108,6 +108,7 @@ CBlockIndex* FindBlockByHeight(int nHeight);
 bool ProcessMessages(CNode* pfrom);
 bool SendMessages(CNode* pto, bool fSendTrickle);
 void GenerateBitcoins(bool fGenerate, CWallet* pwallet);
+int64 GetBlockValue(int nHeight, int64 nFees);
 CBlock* CreateNewBlock(CReserveKey& reservekey);
 void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& nExtraNonce, int64& nPrevTime);
 void IncrementExtraNonceWithAux(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& nExtraNonce, int64& nPrevTime, std::vector<unsigned char>& vchAux);

--- a/src/namecoin.cpp
+++ b/src/namecoin.cpp
@@ -40,7 +40,6 @@ extern std::map<uint160, std::vector<unsigned char> > mapMyNameHashes;
 extern uint256 SignatureHash(CScript scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType);
 
 // forward decls
-extern bool DecodeNameScript(const CScript& script, int& op, vector<vector<unsigned char> > &vvch, CScript::const_iterator& pc);
 extern bool Solver(const CKeyStore& keystore, const CScript& scriptPubKey, uint256 hash, int nHashType, CScript& scriptSigRet);
 extern bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const CTransaction& txTo, unsigned int nIn, int nHashType);
 extern bool IsConflictedTx(CTxDB& txdb, const CTransaction& tx, vector<unsigned char>& name);

--- a/src/namecoin.h
+++ b/src/namecoin.h
@@ -85,6 +85,7 @@ int GetDisplayExpirationDepth(int nHeight);
 bool GetNameOfTx(const CTransaction& tx, std::vector<unsigned char>& name);
 bool GetValueOfNameTx(const CTransaction& tx, std::vector<unsigned char>& value);
 bool DecodeNameTx(const CTransaction& tx, int& op, int& nOut, std::vector<std::vector<unsigned char> >& vvch, int nHeight);
+bool DecodeNameScript(const CScript& script, int& op, std::vector<std::vector<unsigned char> > &vvch, CScript::const_iterator& pc);
 bool DecodeNameScript(const CScript& script, int& op, std::vector<std::vector<unsigned char> > &vvch);
 bool GetNameAddress(const CTransaction& tx, std::string& strAddress);
 std::string SendMoneyWithInputTx(CScript scriptPubKey, int64 nValue, int64 nNetFee, CWalletTx& wtxIn, CWalletTx& wtxNew, bool fAskFee);

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1322,11 +1322,8 @@ bool VerifySignature(const CTransaction& txFrom, const CTransaction& txTo, unsig
 
 bool ExtractDestination(const CScript& scriptPubKey, std::string& addressRet)
 {
-    uint160 h;
-    if (!ExtractHash160(scriptPubKey, h))
-        return false;
-    addressRet = Hash160ToAddress(h);
-    return true;
+    addressRet = scriptPubKey.GetBitcoinAddress();
+    return (addressRet != "");
 }
 
 static CScript PushAll(const vector<valtype>& values)


### PR DESCRIPTION
Extend the information shown for decoded transactions using the rawtx RPC interface.  See https://nf.bit/viewtopic.php?f=11&t=1701.
