### PR TITLE
Port over async RPC calls from Huntercoin, implement "waitforblock" RPC call.

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -3081,6 +3081,21 @@ Value getrawmempool(const Array& params, bool fHelp)
     return a;
 }
 
+/* Block until a new block is found and return only then.  */
+static Value
+waitforblock (const Array& params, bool fHelp)
+{
+  if (fHelp || params.size () > 1)
+    throw runtime_error (
+      "waitforblock [blockHash]\n"
+      "Wait for a change in the best chain (a new block being found)"
+      " and return the new block's hash when it arrives.  If blockHash"
+      " is given, wait until a block with different hash is found.\n");
+
+  Sleep (10000);
+
+  return "some hash";
+}
 
 
 //
@@ -3153,6 +3168,7 @@ pair<string, rpcfn_type> pCallTable[] =
     make_pair("signrawtransaction",    &signrawtransaction),
     make_pair("sendrawtransaction",    &sendrawtransaction),
     make_pair("getrawmempool",         &getrawmempool),
+    make_pair("waitforblock",          &waitforblock),
 };
 map<string, rpcfn_type> mapCallTable(pCallTable, pCallTable + sizeof(pCallTable)/sizeof(pCallTable[0]));
 
@@ -3190,7 +3206,11 @@ set<string> setAllowInSafeMode(pAllowInSafeMode, pAllowInSafeMode + sizeof(pAllo
 
 /* Methods that will be called in a new thread and can block waiting for
    some condition without hurting the RPC server performance.  */
-set<string> setCallAsync;
+string pCallAsync[] =
+{
+    "waitforblock",
+};
+set<string> setCallAsync(pCallAsync, pCallAsync + sizeof(pCallAsync)/sizeof(pCallAsync[0]));
 
 
 

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -3574,6 +3574,10 @@ ExecuteRpcCall (ClientConnectionOutput* out, rpcfn_type method,
       string strReply = JSONRPCReply (result, json_spirit::Value::null, id);
       out->getStream () << HTTPReply (200, strReply) << std::flush;
     }
+  catch (Object& objError)
+    {
+      ErrorReply (out->getStream (), objError, id);
+    }
   catch (const boost::thread_interrupted& e)
     {
       ErrorReply (out->getStream (),

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -3698,6 +3698,9 @@ void ThreadRPCServer2(void* parg)
         vnThreadsRunning[4]--;
         out->waitForConnection (acceptor, peer);
         vnThreadsRunning[4]++;
+
+        /* Note:  This isn't usually called since the thread blocks
+           in the routine above until the program terminates.  */
         if (fShutdown)
         {
             printf("Waiting for %d async RPC call threads to finish...\n",

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -69,6 +69,9 @@ enum RPCErrorCode
     RPC_WALLET_WRONG_ENC_STATE      = -15, // Command given in wrong wallet encryption state (encrypting an encrypted wallet etc.)
     RPC_WALLET_ENCRYPTION_FAILED    = -16, // Failed to encrypt the wallet
     RPC_WALLET_ALREADY_UNLOCKED     = -17, // Wallet is already unlocked
+
+    // Async method call interrupted.
+    RPC_ASYNC_INTERRUPT             = -100,
 };
 
 #endif

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -31,6 +31,10 @@ void RPCTypeCheck(const json_spirit::Object& o,
 extern std::string HelpRequiringPassphrase();
 extern void EnsureWalletIsUnlocked();
 
+typedef json_spirit::Value(*rpcfn_type)(const json_spirit::Array& params, bool fHelp);
+extern std::map<std::string, rpcfn_type> mapCallTable;
+extern std::set<std::string> setCallAsync;
+
 // Bitcoin RPC error codes
 enum RPCErrorCode
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,9 @@ set<CWallet*> setpwalletRegistered;
 
 CCriticalSection cs_main;
 
+boost::mutex mut_newBlock;
+boost::condition_variable cv_newBlock;
+
 map<uint256, CTransaction> mapTransactions;
 CCriticalSection cs_mapTransactions;
 unsigned int nTransactionsUpdated = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1388,6 +1388,10 @@ bool CBlock::SetBestChain(CTxDB& txdb, CBlockIndex* pindexNew)
     nTransactionsUpdated++;
     printf("SetBestChain: new best=%s  height=%d  work=%s\n", hashBestChain.ToString().substr(0,20).c_str(), nBestHeight, bnBestChainWork.ToString().c_str());
 
+    /* When everything is done, notify threads waiting for a change in the
+       currently best chain.  */
+    cv_newBlock.notify_all ();
+
     return true;
 }
 

--- a/src/main.h
+++ b/src/main.h
@@ -12,6 +12,7 @@
 
 #include <list>
 #include <boost/shared_ptr.hpp>
+#include <boost/thread/thread.hpp>
 
 #ifdef __WXMSW__
 #include <io.h> /* for _commit */
@@ -75,6 +76,11 @@ extern int64 nHPSTimerStart;
 extern int64 nTimeBestReceived;
 extern CCriticalSection cs_setpwalletRegistered;
 extern std::set<CWallet*> setpwalletRegistered;
+
+/* Synchronisation and condition variable for threads waiting to be notified
+   when a new block arrives.  */
+extern boost::mutex mut_newBlock;
+extern boost::condition_variable cv_newBlock;
 
 // Settings
 extern int fGenerateBitcoins;

--- a/src/namecoin.cpp
+++ b/src/namecoin.cpp
@@ -21,8 +21,6 @@ using namespace std;
 using namespace json_spirit;
 
 static const bool NAME_DEBUG = false;
-typedef Value(*rpcfn_type)(const Array& params, bool fHelp);
-extern map<string, rpcfn_type> mapCallTable;
 extern int64 AmountFromValue(const Value& value);
 extern Object JSONRPCError(int code, const string& message);
 template<typename T> void ConvertTo(Value& value, bool fAllowNull=false);

--- a/src/namecoin.cpp
+++ b/src/namecoin.cpp
@@ -17,6 +17,8 @@
 #include "json/json_spirit_utils.h"
 #include <boost/xpressive/xpressive_dynamic.hpp>
 
+#include <boost/thread/thread.hpp>
+
 using namespace std;
 using namespace json_spirit;
 

--- a/src/namecoin.cpp
+++ b/src/namecoin.cpp
@@ -17,8 +17,6 @@
 #include "json/json_spirit_utils.h"
 #include <boost/xpressive/xpressive_dynamic.hpp>
 
-#include <boost/thread/thread.hpp>
-
 using namespace std;
 using namespace json_spirit;
 


### PR DESCRIPTION
Port over the possibility to execute RPC calls asynchronously that has been integrated in Huntercoin for some time now.  Use it to implement a new "waitforblock" call that blocks and only returns when a new block is found - this can be used to update block explorers or other front-ends in near real-time when things change, without needing to repeatedly poll the RPC interface for changes.
