### PR TITLE
Remove auxpow from CBlockIndex

### DIFF
--- a/namecoin-qt.pro
+++ b/namecoin-qt.pro
@@ -1,7 +1,7 @@
 TEMPLATE = app
 TARGET = namecoin-qt
 macx:TARGET = "Namecoin-Qt"
-VERSION = 0.3.72
+VERSION = 0.3.74
 INCLUDEPATH += src src/json src/qt
 QT += network
 DEFINES += GUI QT_GUI BOOST_THREAD_USE_LIB BOOST_SPIRIT_THREADSAFE

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -5,7 +5,6 @@
 #include "headers.h"
 #include "db.h"
 #include "net.h"
-#include "auxpow.h"
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 
@@ -537,8 +536,6 @@ bool CTxDB::LoadBlockIndex()
             pindexNew->nTime          = diskindex.nTime;
             pindexNew->nBits          = diskindex.nBits;
             pindexNew->nNonce         = diskindex.nNonce;
-            pindexNew->auxpow.reset ();
-            pindexNew->hasAuxpow      = diskindex.hasAuxpow;
 
             // Watch for genesis block
             if (pindexGenesisBlock == NULL && diskindex.GetBlockHash() == hashGenesisBlock)

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -363,60 +363,6 @@ bool CTxDB::ContainsTx(uint256 hash)
     return Exists(make_pair(string("tx"), hash));
 }
 
-bool CTxDB::ReadOwnerTxes(uint160 hash160, int nMinHeight, vector<CTransaction>& vtx)
-{
-    assert(!fClient);
-    vtx.clear();
-
-    // Get cursor
-    Dbc* pcursor = GetCursor();
-    if (!pcursor)
-        return false;
-
-    unsigned int fFlags = DB_SET_RANGE;
-    loop
-    {
-        // Read next record
-        CDataStream ssKey;
-        if (fFlags == DB_SET_RANGE)
-            ssKey << string("owner") << hash160 << CDiskTxPos(0, 0, 0);
-        CDataStream ssValue;
-        int ret = ReadAtCursor(pcursor, ssKey, ssValue, fFlags);
-        fFlags = DB_NEXT;
-        if (ret == DB_NOTFOUND)
-            break;
-        else if (ret != 0)
-        {
-            pcursor->close();
-            return false;
-        }
-
-        // Unserialize
-        string strType;
-        uint160 hashItem;
-        CDiskTxPos pos;
-        ssKey >> strType >> hashItem >> pos;
-        int nItemHeight;
-        ssValue >> nItemHeight;
-
-        // Read transaction
-        if (strType != "owner" || hashItem != hash160)
-            break;
-        if (nItemHeight >= nMinHeight)
-        {
-            vtx.resize(vtx.size()+1);
-            if (!vtx.back().ReadFromDisk(pos))
-            {
-                pcursor->close();
-                return false;
-            }
-        }
-    }
-
-    pcursor->close();
-    return true;
-}
-
 bool CTxDB::ReadDiskTx(uint256 hash, CTransaction& tx, CTxIndex& txindex)
 {
     assert(!fClient);

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -537,14 +537,12 @@ bool CTxDB::LoadBlockIndex()
             pindexNew->nTime          = diskindex.nTime;
             pindexNew->nBits          = diskindex.nBits;
             pindexNew->nNonce         = diskindex.nNonce;
-            pindexNew->auxpow         = diskindex.auxpow;
+            pindexNew->auxpow.reset ();
+            pindexNew->hasAuxpow      = diskindex.hasAuxpow;
 
             // Watch for genesis block
             if (pindexGenesisBlock == NULL && diskindex.GetBlockHash() == hashGenesisBlock)
                 pindexGenesisBlock = pindexNew;
-
-            if (!pindexNew->CheckIndex())
-                return error("LoadBlockIndex() : CheckIndex failed at %d", pindexNew->nHeight);
         }
         else
         {

--- a/src/db.h
+++ b/src/db.h
@@ -288,7 +288,6 @@ public:
     bool AddTxIndex(const CTransaction& tx, const CDiskTxPos& pos, int nHeight);
     bool EraseTxIndex(const CTransaction& tx);
     bool ContainsTx(uint256 hash);
-    bool ReadOwnerTxes(uint160 hash160, int nHeight, std::vector<CTransaction>& vtx);
     bool ReadDiskTx(uint256 hash, CTransaction& tx, CTxIndex& txindex);
     bool ReadDiskTx(uint256 hash, CTransaction& tx);
     bool ReadDiskTx(COutPoint outpoint, CTransaction& tx, CTxIndex& txindex);

--- a/src/db.h
+++ b/src/db.h
@@ -258,6 +258,14 @@ public:
     }
     
     bool static Rewrite(const std::string& strFile, const char* pszSkip = NULL);
+
+    /* Rewrite the DB with this database's name.  This closes it.  */
+    inline bool
+    Rewrite ()
+    {
+      Close ();
+      Rewrite (strFile);
+    }
 };
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -705,14 +705,9 @@ CBlockIndex* FindBlockByHeight(int nHeight)
     return pblockindex;
 }
 
-bool CBlock::ReadFromDisk(const CBlockIndex* pindex, bool fReadTransactions)
+bool CBlock::ReadFromDisk(const CBlockIndex* pindex)
 {
-    if (!fReadTransactions)
-    {
-        *this = pindex->GetBlockHeader();
-        return true;
-    }
-    if (!ReadFromDisk(pindex->nFile, pindex->nBlockPos, fReadTransactions))
+    if (!ReadFromDisk(pindex->nFile, pindex->nBlockPos, true))
         return false;
     if (GetHash() != pindex->GetBlockHash())
         return error("CBlock::ReadFromDisk() : GetHash() doesn't match index");
@@ -2376,7 +2371,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
             }
             pfrom->PushInventory(CInv(MSG_BLOCK, pindex->GetBlockHash()));
             CBlock block;
-            block.ReadFromDisk(pindex, true);
+            block.ReadFromDisk(pindex);
             nBytes += block.GetSerializeSize(SER_NETWORK);
             if (--nLimit <= 0 || nBytes >= SendBufferSize()/2)
             {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1762,10 +1762,8 @@ bool LoadBlockIndex(bool fAllowNew)
 
     hooks->MessageStart(pchMessageStart);
 
-    //
-    // Load block index.  Update to the new format (without auxpow)
-    // if necessary.
-    //
+    /* Load block index.  Update to the new format (without auxpow)
+       if necessary.  */
     {
       CTxDB txdb("cr");
       if (!txdb.LoadBlockIndex())
@@ -1788,6 +1786,9 @@ bool LoadBlockIndex(bool fAllowNew)
                 wtxdb.WriteBlockIndex (disk);
               }
             wtxdb.WriteVersion (37400);
+
+            /* Rewrite the database to compact the storage format.  */
+            wtxdb.Rewrite ();
           }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2392,6 +2392,11 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
 
     else if (strCommand == "getheaders")
     {
+        /* 'getheaders' is never sent by the client code and thus also
+           not well tested.  Disable it for this reason until it is actually
+           used by some clients in production.  */
+        printf ("warning: ignored 'getheaders' message\n");
+#if 0
         CBlockLocator locator;
         uint256 hashStop;
         vRecv >> locator >> hashStop;
@@ -2424,6 +2429,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         }
 
         pfrom->PushMessage("headers", vHeaders);
+#endif
     }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3488,19 +3488,10 @@ void GenerateBitcoins(bool fGenerate, CWallet* pwallet)
 
 std::string CBlockIndex::ToString() const
 {
-    const char* auxpowStr;
-    if (!hasAuxpow)
-      auxpowStr = "-";
-    else if (auxpow)
-      auxpowStr = auxpow->GetParentBlockHash ().ToString ().substr (0, 20).c_str ();
-    else
-      auxpowStr = "<not loaded>";
-
-    return strprintf("CBlockIndex(nprev=%08x, pnext=%08x, nFile=%d, nBlockPos=%-6d nHeight=%d, merkle=%s, hashBlock=%s, hashParentBlock=%s)",
+    return strprintf("CBlockIndex(nprev=%08x, pnext=%08x, nFile=%d, nBlockPos=%-6d nHeight=%d, merkle=%s, hashBlock=%s)",
             pprev, pnext, nFile, nBlockPos, nHeight,
             hashMerkleRoot.ToString().substr(0,10).c_str(),
-            GetBlockHash().ToString().substr(0,20).c_str(),
-            auxpowStr);
+            GetBlockHash().ToString().substr(0,20).c_str());
 }
 
 CMapBlockIndex::~CMapBlockIndex ()

--- a/src/main.h
+++ b/src/main.h
@@ -1092,13 +1092,6 @@ public:
     unsigned int nBits;
     unsigned int nNonce;
 
-    /* If this is an aux work block, store a pointer to the auxpow here.
-       Note that this is not saved on disk for performance (instead, it needs
-       to be leaded from the block chain itself when needed).  Instead,
-       a flag is stored to record whether or not there is an auxpow.  */
-    bool hasAuxpow;
-    mutable boost::shared_ptr<CAuxPow> auxpow;
-
 public:
 
     CBlockIndex()
@@ -1116,8 +1109,6 @@ public:
         nTime          = 0;
         nBits          = 0;
         nNonce         = 0;
-        hasAuxpow      = false;
-        auxpow.reset();
     }
 
     CBlockIndex(unsigned int nFileIn, unsigned int nBlockPosIn, CBlock& block)
@@ -1135,8 +1126,6 @@ public:
         nTime          = block.nTime;
         nBits          = block.nBits;
         nNonce         = block.nNonce;
-        hasAuxpow      = static_cast<bool> (block.auxpow);
-        auxpow         = block.auxpow;
     }
 
     /* GetBlockHeader is never actually used in the code, thus disable
@@ -1292,16 +1281,12 @@ public:
         READWRITE(nBits);
         READWRITE(nNonce);
 
-        /* In the old format, the auxpow is stored.  Load it if this
-           is the case to set the hasAuxpow flag.  Otherwise, only
-           store the flag instead of the full auxpow.  */
+        /* In the old format, the auxpow is stored.  Load it and ignore.  */
         if ((nType & SER_DISK) && fRead && nVersion < 37400)
         {
+            boost::shared_ptr<CAuxPow> auxpow;
             ReadWriteAuxPow(s, auxpow, nType, this->nVersion, ser_action);
-            const_cast<CDiskBlockIndex*> (this)->hasAuxpow = static_cast<bool> (auxpow);
         }
-        else
-            READWRITE(hasAuxpow);
     )
 
     uint256 GetBlockHash() const

--- a/src/main.h
+++ b/src/main.h
@@ -1054,7 +1054,7 @@ public:
 
     bool DisconnectBlock(CTxDB& txdb, CBlockIndex* pindex);
     bool ConnectBlock(CTxDB& txdb, CBlockIndex* pindex);
-    bool ReadFromDisk(const CBlockIndex* pindex, bool fReadTransactions=true);
+    bool ReadFromDisk(const CBlockIndex* pindex);
     bool SetBestChain(CTxDB& txdb, CBlockIndex* pindexNew);
     bool AddToBlockIndex(unsigned int nFile, unsigned int nBlockPos);
     bool CheckBlock(int nHeight) const;
@@ -1139,6 +1139,10 @@ public:
         auxpow         = block.auxpow;
     }
 
+    /* GetBlockHeader is never actually used in the code, thus disable
+       it since it can't reliably be tested.  It can be re-enabled
+       when necessary later.  */
+#if 0
     CBlock GetBlockHeader() const
     {
         CBlock block;
@@ -1167,6 +1171,7 @@ public:
 
         return block;
     }
+#endif
 
     uint256 GetBlockHash() const
     {

--- a/src/main.h
+++ b/src/main.h
@@ -1282,7 +1282,7 @@ public:
         READWRITE(nNonce);
 
         /* In the old format, the auxpow is stored.  Load it and ignore.  */
-        if ((nType & SER_DISK) && fRead && nVersion < 37400)
+        if (fRead && nVersion < 37400)
         {
             boost::shared_ptr<CAuxPow> auxpow;
             ReadWriteAuxPow(s, auxpow, nType, this->nVersion, ser_action);

--- a/src/namecoin.cpp
+++ b/src/namecoin.cpp
@@ -1595,7 +1595,7 @@ bool CNameDB::ReconstructNameIndex()
         {  
             TxnBegin();
             CBlock block;
-            block.ReadFromDisk(pindex, true);
+            block.ReadFromDisk(pindex);
             int nHeight = pindex->nHeight;
             
             BOOST_FOREACH(CTransaction& tx, block.vtx)

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -35,7 +35,7 @@ class CDataStream;
 class CAutoFile;
 static const unsigned int MAX_SIZE = 0x02000000;
 
-static const int VERSION = 37300;
+static const int VERSION = 37400;
 static const char* pszSubVer = "";
 static const bool VERSION_IS_BETA = false;
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -510,7 +510,7 @@ int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate)
         while (pindex)
         {
             CBlock block;
-            block.ReadFromDisk(pindex, true);
+            block.ReadFromDisk(pindex);
             BOOST_FOREACH(CTransaction& tx, block.vtx)
             {
                 if (AddToWalletIfInvolvingMe(tx, &block, fUpdate))


### PR DESCRIPTION
Remove the auxpow field from CBlockIndex and thus also from blkindex.dat.  This field is never actually used in the current code - when other "dead" code is also removed, as done in this patch.  This reduces the storage required for blkindex.dat from 490 MiB to around 270 MiB, and increases the start-up performance dramatically for me.  (The "Loading block index..." stage takes now only 17 seconds instead of 700 seconds before!)  Also, memory usage should be reduced by around the same amount as blkindex.dat.
