### PR TITLE
name_pending and getchains RPC commands

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 v0.3.74
 ======
+* new rpc commands: name_pending, getchains (Domob)
 * Simplified blkindex.dat for smaller file size and faster startup - not backward compatible ("remove auxpow", Domob) - IT WILL TAKE A WHILE FOR THE REWRITE ON THE FIRST START
 * Implement name_update in createrawtransaction (Domob)
 * More detailed JSON outputs for decoderawtransaction and getrawtransaction (Domob)

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -373,6 +373,84 @@ Value getblock(const Array& params, bool fHelp)
     return BlockToValue(block);
 }
 
+/* Comparison function for sorting the getchains heads.  */
+static bool
+compareBlocksByHeight (const uint256& a, const uint256& b)
+{
+  std::map<uint256, CBlockIndex*>::const_iterator ia, ib;
+
+  ia = mapBlockIndex.find (a);
+  ib = mapBlockIndex.find (b);
+
+  assert (ia != mapBlockIndex.end () && ib != mapBlockIndex.end ());
+
+  return (ia->second->nHeight > ib->second->nHeight);
+}
+
+/* Return the state of all known chains.  */
+static Value
+getchains (const Array& params, bool fHelp)
+{
+  if (fHelp || params.size () != 0)
+    throw runtime_error (
+      "getchains\n"
+      "Return status of all known chains.");
+
+  /* Lock everything.  Not sure if this is needed for the whole duration
+     of the call, but better be safe than sorry.  */
+  CCriticalBlock lock(cs_main);
+
+  /* For each block known, keep track if there are follow-ups (which have
+     the block as pprev) so that we find the chain heads.  */
+
+  std::map<uint256, bool> blockIsHead;
+  std::map<uint256, CBlockIndex*>::const_iterator i;
+
+  for (i = mapBlockIndex.begin (); i != mapBlockIndex.end (); ++i)
+    blockIsHead.insert (std::make_pair (i->first, true));
+
+  for (i = mapBlockIndex.begin (); i != mapBlockIndex.end (); ++i)
+    {
+      const CBlockIndex* pprev = i->second->pprev;
+      if (!pprev)
+        continue;
+
+      const uint256 prevHash = *pprev->phashBlock;
+      const std::map<uint256, bool>::iterator j = blockIsHead.find (prevHash);
+      assert (j != blockIsHead.end ());
+      j->second = false;
+    }
+
+  /* Get chain heads and sort them by height.  */
+
+  std::vector<uint256> heads;
+  for (std::map<uint256, bool>::const_iterator j = blockIsHead.begin ();
+       j != blockIsHead.end (); ++j)
+    if (j->second)
+      heads.push_back (j->first);
+
+  std::sort (heads.begin (), heads.end (), &compareBlocksByHeight);
+
+  /* Construct the output array.  */
+
+  Array res;
+  for (std::vector<uint256>::const_iterator j = heads.begin ();
+       j != heads.end (); ++j)
+    {
+      i = mapBlockIndex.find (*j);
+      assert (i != mapBlockIndex.end ());
+      const CBlockIndex& block = *i->second;
+
+      assert (*j == *block.phashBlock);
+
+      Object obj;
+      obj.push_back (Pair ("height", block.nHeight));
+      obj.push_back (Pair ("hash", block.phashBlock->GetHex ()));
+      res.push_back (obj);
+    }
+
+  return res;
+}
 
 Value getconnectioncount(const Array& params, bool fHelp)
 {
@@ -3245,6 +3323,7 @@ pair<string, rpcfn_type> pCallTable[] =
     make_pair("getblockcount",         &getblockcount),
     make_pair("getblockhash",          &getblockhash),
     make_pair("getblocknumber",        &getblocknumber),
+    make_pair("getchains",             &getchains),
     make_pair("getconnectioncount",    &getconnectioncount),
     make_pair("getdifficulty",         &getdifficulty),
     make_pair("getgenerate",           &getgenerate),

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -20,7 +20,6 @@
 #include <boost/thread/thread.hpp>
 
 #include <memory>
-#include <list>
 
 #ifdef USE_SSL
 #include <boost/asio/ssl.hpp> 

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -7,6 +7,12 @@
 
 #include "json/json_spirit.h"
 
+#include <map>
+#include <list>
+#include <set>
+#include <string>
+#include <vector>
+
 void ThreadRPCServer(void* parg);
 json_spirit::Array RPCConvertValues(const std::string &strMethod, const std::vector<std::string> &strParams);
 void RPCConvertValues(const std::string &strMethod, json_spirit::Array &params);

--- a/src/namecoin.cpp
+++ b/src/namecoin.cpp
@@ -1301,7 +1301,7 @@ name_pending (const Array& params, bool fHelp)
 
               int op, nOut;
               std::vector<vchType> vvch;
-              if (!DecodeNameTx (tx, op, nOut, vvch))
+              if (!DecodeNameTx (tx, op, nOut, vvch, -1))
                 {
                   printf ("name_pending: failed to find name output in tx %s\n",
                           j->GetHex ().c_str ());


### PR DESCRIPTION
This patch ports over two RPC commands from Huntercoin:

name_pending:  Shows pending name_update and name_firstupdate transactions in the memory pool.  This can be useful both for a future RPC-based UI (to show, for instance, your own pending transactions) and also for general-purpose debugging / block explorers or whatever.

getchains:  Show information about all known blocks and their relationship in the "tree" of known blocks.  This can be used to find and analyse chain forks and orphan blocks.
