### PR TITLE
Further update blkindex.dat by changing the vSpent format

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,6 @@
-v0.3.74
+* Even smaller blkindex.dat. Not backward compatible. It will take a while for the rewrite on the first start. (Domob)
+
+v0.3.74-rc1 (never officially released)
 ======
 * allow for atomic name transactions via rpc commands (Domob)
 * new rpc commands: name_pending, getchains (Domob)

--- a/namecoin-qt.pro
+++ b/namecoin-qt.pro
@@ -1,7 +1,7 @@
 TEMPLATE = app
 TARGET = namecoin-qt
 macx:TARGET = "Namecoin-Qt"
-VERSION = 0.3.74
+VERSION = 0.3.75
 INCLUDEPATH += src src/json src/qt
 QT += network
 DEFINES += GUI QT_GUI BOOST_THREAD_USE_LIB BOOST_SPIRIT_THREADSAFE

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -187,7 +187,7 @@ void static CheckpointLSN(const std::string &strFile)
     dbenv.lsn_reset(strFile.c_str(), 0);
 }
 
-bool CDB::Rewrite(const string& strFile, const char* pszSkip)
+bool CDB::Rewrite(const string& strFile)
 {
     while (!fShutdown)
     {
@@ -236,15 +236,6 @@ bool CDB::Rewrite(const string& strFile, const char* pszSkip)
                                 pcursor->close();
                                 fSuccess = false;
                                 break;
-                            }
-                            if (pszSkip &&
-                                strncmp(&ssKey[0], pszSkip, std::min(ssKey.size(), strlen(pszSkip))) == 0)
-                                continue;
-                            if (strncmp(&ssKey[0], "\x07version", 8) == 0)
-                            {
-                                // Update version:
-                                ssValue.clear();
-                                ssValue << VERSION;
                             }
                             Dbt datKey(&ssKey[0], ssKey.size());
                             Dbt datValue(&ssValue[0], ssValue.size());

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -44,7 +44,8 @@ public:
 instance_of_cdbinit;
 
 
-CDB::CDB(const char* pszFile, const char* pszMode) : pdb(NULL)
+CDB::CDB(const char* pszFile, const char* pszMode)
+  : pdb(NULL), nVersion(VERSION)
 {
     int ret;
     if (pszFile == NULL)

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -476,6 +476,7 @@ bool CTxDB::LoadBlockIndex()
         if (strType == "blockindex")
         {
             CDiskBlockIndex diskindex;
+            SetStreamVersion (ssValue);
             ssValue >> diskindex;
 
             // Construct block index object

--- a/src/db.h
+++ b/src/db.h
@@ -340,6 +340,9 @@ public:
     bool ReadBestInvalidWork(CBigNum& bnBestInvalidWork);
     bool WriteBestInvalidWork(CBigNum bnBestInvalidWork);
     bool LoadBlockIndex();
+
+    /* Update txindex to new data format.  */
+    bool RewriteTxIndex (int oldVersion);
 };
 
 

--- a/src/db.h
+++ b/src/db.h
@@ -59,6 +59,10 @@ private:
     CDB(const CDB&);
     void operator=(const CDB&);
 
+    /* Store version of the DB here that will be set as version
+       for serialisation on the streams.  */
+    int nVersion;
+
 protected:
     template<typename K, typename T>
     bool Read(const K& key, T& value)
@@ -67,7 +71,7 @@ protected:
             return false;
 
         // Key
-        CDataStream ssKey(SER_DISK);
+        CDataStream ssKey(SER_DISK, nVersion);
         ssKey.reserve(1000);
         ssKey << key;
         Dbt datKey(&ssKey[0], ssKey.size());
@@ -81,7 +85,9 @@ protected:
             return false;
 
         // Unserialize value
-        CDataStream ssValue((char*)datValue.get_data(), (char*)datValue.get_data() + datValue.get_size(), SER_DISK);
+        CDataStream ssValue((char*)datValue.get_data(),
+                            (char*)datValue.get_data() + datValue.get_size(),
+                            SER_DISK, nVersion);
         ssValue >> value;
 
         // Clear and free memory
@@ -99,13 +105,13 @@ protected:
             assert(("Write called on database in read-only mode", false));
 
         // Key
-        CDataStream ssKey(SER_DISK);
+        CDataStream ssKey(SER_DISK, nVersion);
         ssKey.reserve(1000);
         ssKey << key;
         Dbt datKey(&ssKey[0], ssKey.size());
 
         // Value
-        CDataStream ssValue(SER_DISK);
+        CDataStream ssValue(SER_DISK, nVersion);
         ssValue.reserve(10000);
         ssValue << value;
         Dbt datValue(&ssValue[0], ssValue.size());
@@ -128,7 +134,7 @@ protected:
             assert(("Erase called on database in read-only mode", false));
 
         // Key
-        CDataStream ssKey(SER_DISK);
+        CDataStream ssKey(SER_DISK, nVersion);
         ssKey.reserve(1000);
         ssKey << key;
         Dbt datKey(&ssKey[0], ssKey.size());
@@ -148,7 +154,7 @@ protected:
             return false;
 
         // Key
-        CDataStream ssKey(SER_DISK);
+        CDataStream ssKey(SER_DISK, nVersion);
         ssKey.reserve(1000);
         ssKey << key;
         Dbt datKey(&ssKey[0], ssKey.size());
@@ -280,6 +286,16 @@ public:
     bool WriteVersion(int nVersion)
     {
         return Write(std::string("version"), nVersion);
+    }
+
+    /**
+     * Set version for stream serialisation.
+     * @param v Version to use for serialisation streams.
+     */
+    inline void
+    SetSerialisationVersion (int v)
+    {
+      nVersion = v;
     }
     
     bool static Rewrite(const std::string& strFile, const char* pszSkip = NULL);

--- a/src/db.h
+++ b/src/db.h
@@ -217,6 +217,14 @@ protected:
         return 0;
     }
 
+    /* Update the stream to our serialisation version.  This is useful
+       for ReadAtCursor users.  */
+    inline void
+    SetStreamVersion (CDataStream& ss) const
+    {
+      ss.nVersion = nVersion;
+    }
+
 public:
     DbTxn* GetTxn()
     {

--- a/src/db.h
+++ b/src/db.h
@@ -306,7 +306,7 @@ public:
       nVersion = v;
     }
     
-    bool static Rewrite(const std::string& strFile, const char* pszSkip = NULL);
+    bool static Rewrite(const std::string& strFile);
 
     /* Rewrite the DB with this database's name.  This closes it.  */
     inline bool

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1792,11 +1792,12 @@ bool LoadBlockIndex(bool fAllowNew)
 
       if (!txdb.LoadBlockIndex())
           return false;
+      txdb.Close ();
 
       if (nVersion < 37500)
         {
-          txdb.Close ();
           CTxDB wtxdb;
+          /* SerialisationVersion is set to VERSION by default.  */
 
           /* Go through each blkindex object loaded into memory and
              write it again to disk.  */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -911,11 +911,11 @@ CTransaction::DisconnectInputs (DatabaseSet& dbset, CBlockIndex* pindex)
             if (!dbset.tx ().ReadTxIndex (prevout.hash, txindex))
                 return error("DisconnectInputs() : ReadTxIndex failed");
 
-            if (prevout.n >= txindex.vSpent.size())
+            if (prevout.n >= txindex.GetOutputCount ())
                 return error("DisconnectInputs() : prevout.n out of range");
 
             // Mark outpoint as not spent
-            txindex.vSpent[prevout.n].SetNull();
+            txindex.MarkUnspent (prevout.n);
 
             // Write back
             if (!dbset.tx ().UpdateTxIndex (prevout.hash, txindex))
@@ -976,7 +976,7 @@ bool CTransaction::FetchInputs(CTxDB& txdb, const map<uint256, CTxIndex>& mapTes
                     txPrev = mi->second;
             }
             if (!fFound)
-                txindex.vSpent.resize(txPrev.vout.size());
+              txindex.ResizeOutputs (txPrev.vout.size ());
         }
         else
         {
@@ -993,12 +993,12 @@ bool CTransaction::FetchInputs(CTxDB& txdb, const map<uint256, CTxIndex>& mapTes
         assert(inputsRet.count(prevout.hash) != 0);
         const CTxIndex& txindex = inputsRet[prevout.hash].first;
         const CTransaction& txPrev = inputsRet[prevout.hash].second;
-        if (prevout.n >= txPrev.vout.size() || prevout.n >= txindex.vSpent.size())
+        if (prevout.n >= txPrev.vout.size() || prevout.n >= txindex.GetOutputCount ())
         {
             // Revisit this if/when transaction replacement is implemented and allows
             // adding inputs:
             fInvalid = true;
-            return /*DoS(100,*/ error("FetchInputs() : %s prevout.n out of range %d %"PRIszu" %"PRIszu" prev tx %s\n%s", GetHash().ToString().substr(0,10).c_str(), prevout.n, txPrev.vout.size(), txindex.vSpent.size(), prevout.hash.ToString().substr(0,10).c_str(), txPrev.ToString().c_str()) /* ) */ ;
+            return /*DoS(100,*/ error("FetchInputs() : %s prevout.n out of range %d %"PRIszu" %"PRIszu" prev tx %s\n%s", GetHash().ToString().substr(0,10).c_str(), prevout.n, txPrev.vout.size(), txindex.GetOutputCount (), prevout.hash.ToString().substr(0,10).c_str(), txPrev.ToString().c_str()) /* ) */ ;
         }
     }
 
@@ -1050,7 +1050,7 @@ CTransaction::ConnectInputs (DatabaseSet& dbset,
                     txPrev = mapTransactions[prevout.hash];
                 }
                 if (!fFound)
-                    txindex.vSpent.resize(txPrev.vout.size());
+                  txindex.ResizeOutputs (txPrev.vout.size ());
             }
             else
             {
@@ -1059,8 +1059,8 @@ CTransaction::ConnectInputs (DatabaseSet& dbset,
                     return error("ConnectInputs() : %s ReadFromDisk prev tx %s failed", GetHash().ToString().substr(0,10).c_str(),  prevout.hash.ToString().substr(0,10).c_str());
             }
 
-            if (prevout.n >= txPrev.vout.size() || prevout.n >= txindex.vSpent.size())
-                return error("ConnectInputs() : %s prevout.n out of range %d %d %d prev tx %s\n%s", GetHash().ToString().substr(0,10).c_str(), prevout.n, txPrev.vout.size(), txindex.vSpent.size(), prevout.hash.ToString().substr(0,10).c_str(), txPrev.ToString().c_str());
+            if (prevout.n >= txPrev.vout.size() || prevout.n >= txindex.GetOutputCount ())
+                return error("ConnectInputs() : %s prevout.n out of range %d %d %d prev tx %s\n%s", GetHash().ToString().substr(0,10).c_str(), prevout.n, txPrev.vout.size(), txindex.GetOutputCount (), prevout.hash.ToString().substr(0,10).c_str(), txPrev.ToString().c_str());
 
             // If prev is coinbase, check that it's matured
             if (txPrev.IsCoinBase())
@@ -1073,8 +1073,8 @@ CTransaction::ConnectInputs (DatabaseSet& dbset,
                 return error("ConnectInputs() : %s VerifySignature failed", GetHash().ToString().substr(0,10).c_str());
 
             // Check for conflicts
-            if (!txindex.vSpent[prevout.n].IsNull())
-                return fMiner ? false : error("ConnectInputs() : %s prev tx already used at %s", GetHash().ToString().substr(0,10).c_str(), txindex.vSpent[prevout.n].ToString().c_str());
+            if (txindex.IsSpent (prevout.n))
+                return fMiner ? false : error("ConnectInputs() : %s prev tx already spent", GetHash().ToString().substr(0,10).c_str());
 
             // Check for negative or overflow input values
             nValueIn += txPrev.vout[prevout.n].nValue;
@@ -1082,7 +1082,7 @@ CTransaction::ConnectInputs (DatabaseSet& dbset,
                 return error("ConnectInputs() : txin values out of range");
 
             // Mark outpoints as spent
-            txindex.vSpent[prevout.n] = posThisTx;
+            txindex.MarkSpent (prevout.n, posThisTx);
 
             // Write back
             if (fBlock)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -915,7 +915,7 @@ CTransaction::DisconnectInputs (DatabaseSet& dbset, CBlockIndex* pindex)
                 return error("DisconnectInputs() : prevout.n out of range");
 
             // Mark outpoint as not spent
-            txindex.MarkUnspent (prevout.n);
+            txindex.SetSpent (prevout.n, false);
 
             // Write back
             if (!dbset.tx ().UpdateTxIndex (prevout.hash, txindex))
@@ -1082,7 +1082,7 @@ CTransaction::ConnectInputs (DatabaseSet& dbset,
                 return error("ConnectInputs() : txin values out of range");
 
             // Mark outpoints as spent
-            txindex.MarkSpent (prevout.n, posThisTx);
+            txindex.SetSpent (prevout.n, true);
 
             // Write back
             if (fBlock)
@@ -1791,7 +1791,7 @@ bool LoadBlockIndex(bool fAllowNew)
 
       int nVersion;
       if (txdb.ReadVersion (nVersion))
-        if (nVersion < 37400)
+        if (nVersion < 37500)
           {
             txdb.Close ();
             CTxDB wtxdb;
@@ -1805,7 +1805,7 @@ bool LoadBlockIndex(bool fAllowNew)
                 CDiskBlockIndex disk(mi->second);
                 wtxdb.WriteBlockIndex (disk);
               }
-            wtxdb.WriteVersion (37400);
+            wtxdb.WriteVersion (37500);
 
             /* Rewrite the database to compact the storage format.  */
             wtxdb.Rewrite ();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1785,16 +1785,16 @@ bool LoadBlockIndex(bool fAllowNew)
     /* Load block index.  Update to the new format (without auxpow)
        if necessary.  */
     {
-      int nVersion = VERSION;
+      int nTxDbVersion = VERSION;
       CTxDB txdb("cr");
-      txdb.ReadVersion (nVersion);
-      txdb.SetSerialisationVersion (nVersion);
+      txdb.ReadVersion (nTxDbVersion);
+      txdb.SetSerialisationVersion (nTxDbVersion);
 
       if (!txdb.LoadBlockIndex())
           return false;
       txdb.Close ();
 
-      if (nVersion < 37500)
+      if (nTxDbVersion < 37500)
         {
           CTxDB wtxdb;
           /* SerialisationVersion is set to VERSION by default.  */
@@ -1811,7 +1811,7 @@ bool LoadBlockIndex(bool fAllowNew)
           wtxdb.WriteVersion (VERSION);
 
           /* Rewrite the txindex.  */
-          wtxdb.RewriteTxIndex (nVersion);
+          wtxdb.RewriteTxIndex (nTxDbVersion);
 
           /* Rewrite the database to compact the storage format.  */
           wtxdb.Rewrite ();

--- a/src/main.h
+++ b/src/main.h
@@ -1356,11 +1356,11 @@ public:
 
         /* In the old format, the auxpow is stored.  Load it and ignore.  */
         if (nVersion < 37400)
-        {
+          {
             assert (fRead);
             boost::shared_ptr<CAuxPow> auxpow;
-            ReadWriteAuxPow(s, auxpow, nType, this->nVersion, ser_action);
-        }
+            ReadWriteAuxPow (s, auxpow, nType, this->nVersion, ser_action);
+          }
     )
 
     uint256 GetBlockHash() const

--- a/src/main.h
+++ b/src/main.h
@@ -794,6 +794,11 @@ public:
     IMPLEMENT_SERIALIZE
     (
         assert (nType == SER_DISK);
+        /* If the version is not up-to-date (with the latest format change
+           for this class), then it means we're upgrading and thus reading
+           and old-format entry.  */
+        assert (nVersion >= 37500 || fRead);
+
         if (nVersion < 37500)
           {
             assert (fRead);

--- a/src/main.h
+++ b/src/main.h
@@ -775,7 +775,13 @@ class CTxIndex
 {
 public:
     CDiskTxPos pos;
+
+    /* vSpent is mostly used as a flag.  While transitioning it to a real
+       bool array, make it private and access it via methods.  */
+private:
     std::vector<CDiskTxPos> vSpent;
+
+public:
 
     CTxIndex()
     {
@@ -805,6 +811,42 @@ public:
     bool IsNull()
     {
         return pos.IsNull();
+    }
+
+    inline unsigned
+    GetOutputCount () const
+    {
+      return vSpent.size ();
+    }
+
+    inline void
+    ResizeOutputs (unsigned n)
+    {
+      vSpent.resize (n);
+    }
+
+    inline bool
+    IsSpent (unsigned n) const
+    {
+      assert (n < vSpent.size ());
+      return !vSpent[n].IsNull ();
+    }
+
+    inline void
+    MarkSpent (unsigned n, const CDiskTxPos& pos)
+    {
+      assert (n < vSpent.size ());
+      assert (vSpent[n].IsNull ());
+      vSpent[n] = pos;
+      assert (!vSpent[n].IsNull ());
+    }
+
+    inline void
+    MarkUnspent (unsigned n)
+    {
+      assert (n < vSpent.size ());
+      assert (!vSpent[n].IsNull ());
+      vSpent[n].SetNull ();
     }
 
     friend bool operator==(const CTxIndex& a, const CTxIndex& b)

--- a/src/main.h
+++ b/src/main.h
@@ -793,8 +793,14 @@ public:
 
     IMPLEMENT_SERIALIZE
     (
-        if (!(nType & SER_GETHASH))
-            READWRITE(nVersion);
+        assert (nType == SER_DISK);
+        if (nVersion < 37500)
+          {
+            assert (fRead);
+            int nVersionDummy;
+            READWRITE(nVersionDummy);
+            assert (nVersionDummy < 37500);
+          }
         READWRITE(pos);
 
         if (nVersion < 37500)

--- a/src/main.h
+++ b/src/main.h
@@ -776,7 +776,7 @@ public:
     CDiskTxPos pos;
 
 private:
-    std::vector<unsigned char> isSpent;
+    std::vector<bool> isSpent;
 
 public:
 
@@ -803,7 +803,7 @@ public:
             std::vector<CDiskTxPos> vSpent;
             READWRITE (vSpent);
 
-            std::vector<unsigned char>& newIsSpent = const_cast<std::vector<unsigned char>&> (isSpent);
+            std::vector<bool>& newIsSpent = const_cast<std::vector<bool>&> (isSpent);
             newIsSpent.resize (vSpent.size ());
             for (unsigned i = 0; i < vSpent.size (); ++i)
               newIsSpent[i] = !vSpent[i].IsNull ();

--- a/src/qt/res/bitcoin-qt.rc
+++ b/src/qt/res/bitcoin-qt.rc
@@ -8,7 +8,7 @@ IDI_ICON1 ICON DISCARDABLE "icons/bitcoin.ico"
 
 #define CLIENT_VERSION_MAJOR 0
 #define CLIENT_VERSION_MINOR 3
-#define CLIENT_VERSION_REVISION 71
+#define CLIENT_VERSION_REVISION 75
 #define CLIENT_VERSION_BUILD 0
 
 // Converts the parameter X to a string after macro replacement on X has been performed.

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -35,7 +35,7 @@ class CDataStream;
 class CAutoFile;
 static const unsigned int MAX_SIZE = 0x02000000;
 
-static const int VERSION = 37400;
+static const int VERSION = 37500;
 static const char* pszSubVer = "";
 static const bool VERSION_IS_BETA = false;
 

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -342,6 +342,17 @@ template<typename Stream, typename T, typename A> void Unserialize_impl(Stream& 
 template<typename Stream, typename T, typename A> void Unserialize_impl(Stream& is, std::vector<T, A>& v, int nType, int nVersion, const boost::false_type&);
 template<typename Stream, typename T, typename A> inline void Unserialize(Stream& is, std::vector<T, A>& v, int nType, int nVersion=VERSION);
 
+// bit vector
+template<typename A>
+  unsigned int GetSerializeSize (const std::vector<bool, A>& v,
+                                 int nType, int nVersion = VERSION);
+template<typename Stream, typename A>
+  void Serialize (Stream& os, const std::vector<bool, A>& v,
+                  int nType, int nVersion = VERSION);
+template<typename Stream, typename A>
+  void Unserialize (Stream& is, std::vector<bool, A>& v,
+                    int nType, int nVersion = VERSION);
+
 // others derived from vector
 extern inline unsigned int GetSerializeSize(const CScript& v, int nType, int nVersion=VERSION);
 template<typename Stream> void Serialize(Stream& os, const CScript& v, int nType, int nVersion=VERSION);
@@ -527,6 +538,64 @@ template<typename Stream, typename T, typename A>
 inline void Unserialize(Stream& is, std::vector<T, A>& v, int nType, int nVersion)
 {
     Unserialize_impl(is, v, nType, nVersion, boost::is_fundamental<T>());
+}
+
+
+
+
+/* bit vector  */
+
+inline unsigned
+GetBitvectorWordCount (unsigned n)
+{
+  return (n + 7) / 8;
+}
+
+template<typename A>
+  unsigned int
+  GetSerializeSize (const std::vector<bool, A>& v,
+                    int nType, int nVersion = VERSION)
+{
+  return GetSizeOfCompactSize (v.size ()) + GetBitvectorWordCount (v.size ());
+}
+
+template<typename Stream, typename A>
+  void
+  Serialize (Stream& os, const std::vector<bool, A>& v,
+             int nType, int nVersion = VERSION)
+{
+  WriteCompactSize (os, v.size ());
+
+  std::vector<unsigned char> words(GetBitvectorWordCount (v.size ()), 0);
+  for (unsigned i = 0; i < v.size (); ++i)
+    if (v[i])
+      {
+        const unsigned wordInd = i / 8;
+        const unsigned bitInd = i % 8;
+        words[wordInd] |= (1 << bitInd);
+      }
+
+  assert (sizeof (words[0]) == 1);
+  os.write (reinterpret_cast<const char*> (&words[0]), words.size ());
+}
+
+template<typename Stream, typename A>
+  void
+  Unserialize (Stream& is, std::vector<bool, A>& v,
+               int nType, int nVersion = VERSION)
+{
+  const unsigned size = ReadCompactSize (is);
+  std::vector<unsigned char> words(GetBitvectorWordCount (size));
+  assert (sizeof (words[0]) == 1);
+  is.read (reinterpret_cast<char*> (&words[0]), words.size ());
+
+  v.resize (size);
+  for (unsigned i = 0; i < v.size (); ++i)
+    {
+      const unsigned wordInd = i / 8;
+      const unsigned bitInd = i % 8;
+      v[i] = (words[wordInd] & (1 << bitInd));
+    }
 }
 
 


### PR DESCRIPTION
This patch replaces the vSpent array in CTxIndex by a bit vector.  The only information actually used in the code is whether or not an output is spent, so this is enough.  This halves the size of blkindex.dat again.  I'm not aware of any memory or start-up improvements, though, but presumably it helps with general operation and blockchain syncing.  (I have no 'measurable results' to show, though, besides the storage reduction.)
