### PR TITLE
Add -dbstats argument from Huntercoin to analyse BDB storage

### DIFF
--- a/src/db.h
+++ b/src/db.h
@@ -266,6 +266,14 @@ public:
       Close ();
       Rewrite (strFile);
     }
+
+    /**
+     * Print some storage stats about the database file for debugging
+     * purposes.
+     * @param file Database file to analyse.
+     */
+    static void PrintStorageStats (const std::string& file);
+
 };
 
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -281,6 +281,18 @@ bool AppInit2(int argc, char* argv[])
         return false;
     }
 
+    /* Debugging feature:  Read a BDB database file and print out some
+       statistics about which keys it contains and how much data they
+       use up in the file.  */
+    if (GetBoolArg ("-dbstats"))
+      {
+        const std::string dbfile = GetArg ("-dbstatsfile", "blkindex.dat");
+        printf ("Database storage stats for '%s' requested.\n",
+                dbfile.c_str ());
+        CDB::PrintStorageStats (dbfile);
+        return true;
+      }
+
     //
     // Limit to single instance per user
     // Required to protect the database files if we're going to keep deleting log.*


### PR DESCRIPTION
Add a new -dbstats argument that can be used to analyse what exactly is stored in a BDB database file. This can be used to help with optimising storage.Analyse db
