### PR TITLE
Enforce value length

### DIFF
--- a/src/namecoin.cpp
+++ b/src/namecoin.cpp
@@ -123,15 +123,19 @@ int64 getAmount(Value value)
     return nAmount;
 }
 
-vector<unsigned char> vchFromValue(const Value& value) {
-    string strName = value.get_str();
-    unsigned char *strbeg = (unsigned char*)strName.c_str();
-    return vector<unsigned char>(strbeg, strbeg + strName.size());
+vchType
+vchFromValue (const Value& value)
+{
+  const std::string str = value.get_str ();
+  return vchFromString (str);
 }
 
-std::vector<unsigned char> vchFromString(const std::string &str) {
-    unsigned char *strbeg = (unsigned char*)str.c_str();
-    return vector<unsigned char>(strbeg, strbeg + str.size());
+vchType
+vchFromString (const std::string& str)
+{
+  const unsigned char* strbeg;
+  strbeg = reinterpret_cast<const unsigned char*> (str.c_str ());
+  return vchType(strbeg, strbeg + str.size ());
 }
 
 string stringFromVch(const vector<unsigned char> &vch) {
@@ -1000,18 +1004,18 @@ Value name_firstupdate(const Array& params, bool fHelp)
                 "Perform a first update after a name_new reservation.\n"
                 "Note that the first update will go into a block 12 blocks after the name_new, at the soonest."
                 + HelpRequiringPassphrase());
-    vector<unsigned char> vchName = vchFromValue(params[0]);
-    vector<unsigned char> vchRand = ParseHex(params[1].get_str());
-    vector<unsigned char> vchValue;
 
-    if (params.size() == 3)
-    {
-        vchValue = vchFromValue(params[2]);
-    }
+    const vchType vchName = vchFromValue (params[0]);
+    const vchType vchRand = ParseHex (params[1].get_str ());
+
+    vchType vchValue;
+    if (params.size () == 3)
+      vchValue = vchFromValue (params[2]);
     else
-    {
-        vchValue = vchFromValue(params[3]);
-    }
+      vchValue = vchFromValue (params[3]);
+
+    if (vchValue.size () > UI_MAX_VALUE_LENGTH)
+      throw JSONRPCError(RPC_INVALID_PARAMETER, "the value is too long");
 
     CWalletTx wtx;
     wtx.nVersion = NAMECOIN_TX_VERSION;
@@ -1130,8 +1134,11 @@ Value name_update(const Array& params, bool fHelp)
                 "name_update <name> <value> [<toaddress>]\nUpdate and possibly transfer a name"
                 + HelpRequiringPassphrase());
 
-    vector<unsigned char> vchName = vchFromValue(params[0]);
-    vector<unsigned char> vchValue = vchFromValue(params[1]);
+    const vchType vchName = vchFromValue (params[0]);
+    const vchType vchValue = vchFromValue (params[1]);
+
+    if (vchValue.size () > UI_MAX_VALUE_LENGTH)
+      throw JSONRPCError(RPC_INVALID_PARAMETER, "the value is too long");
 
     CWalletTx wtx;
     wtx.nVersion = NAMECOIN_TX_VERSION;

--- a/src/namecoin.h
+++ b/src/namecoin.h
@@ -14,6 +14,12 @@ static const int OP_NAME_UPDATE = 0x03;
 static const int OP_NAME_NOP = 0x04;
 static const int MIN_FIRSTUPDATE_DEPTH = 12;
 
+/* Maximum value length that is allowed by the UIs.  Currently,
+   if the value is set above 520 bytes, it can't ever be updated again
+   due to limitations in the scripting system.  Enforce this
+   in the UIs.  */
+static const int UI_MAX_VALUE_LENGTH = 520;
+
 class CNameDB;
 class CNameIndex;
 class CDiskTxPos;

--- a/src/qt/configurenamedialog.cpp
+++ b/src/qt/configurenamedialog.cpp
@@ -40,7 +40,7 @@ ConfigureNameDialog::ConfigureNameDialog(const QString &name_, const QString &da
     ui->labelAddress->setText(GUIUtil::HtmlEscape(address));
     ui->labelAddress->setFont(GUIUtil::bitcoinAddressFont());
 
-    ui->dataEdit->setMaxLength(GUI_MAX_VALUE_LENGTH);
+    ui->dataEdit->setMaxLength (UI_MAX_VALUE_LENGTH);
 
     returnData = data;
 

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -28,10 +28,6 @@ static const int TOOLTIP_WRAP_THRESHOLD = 80;
 /* Maximum allowed URI length */
 static const int MAX_URI_LENGTH = 255;
 
-// Should be set to MAX_VALUE_LENGTH (from namecoin.h) when it's supported by the network
-// (currently due to limitations of CScript the limit is 519 bytes)
-static const int GUI_MAX_VALUE_LENGTH = 519;
-
 /* QRCodeDialog -- size of exported QR Code image */
 #define EXPORT_IMAGE_SIZE 256
 

--- a/src/qt/managenamespage.cpp
+++ b/src/qt/managenamespage.cpp
@@ -111,9 +111,9 @@ ManageNamesPage::ManageNamesPage(QWidget *parent) :
 
     ui->registerName->setMaxLength(MAX_NAME_LENGTH);
     
-    ui->nameFilter->setMaxLength(MAX_NAME_LENGTH);
-    ui->valueFilter->setMaxLength(GUI_MAX_VALUE_LENGTH);
-    GUIUtil::setupAddressWidget(ui->addressFilter, this, true);
+    ui->nameFilter->setMaxLength (MAX_NAME_LENGTH);
+    ui->valueFilter->setMaxLength (UI_MAX_VALUE_LENGTH);
+    GUIUtil::setupAddressWidget (ui->addressFilter, this, true);
     
 #if QT_VERSION >= 0x040700
     /* Do not move this to the XML file, Qt before 4.7 will choke on it */


### PR DESCRIPTION
Disallow values longer than 520 bytes in the RPC commands name_update and name_firstupdate, and unify it with the value check in the Qt.  I've tested that this successfully prevents "stuck names" on test-net, but it would be good if someone independently confirms that 520 byte values are still ok while 521 bytes make the name stuck (and that the patch guards against this).
