### PR TITLE
Port from namecoin-qt

### DIFF
--- a/src/hook.h
+++ b/src/hook.h
@@ -33,8 +33,8 @@ public:
     virtual int LockinHeight() = 0;
     virtual std::string IrcPrefix() = 0;
     virtual void MessageStart(char* pchMessageStart) = 0;
-    virtual void AcceptToMemoryPool(DatabaseSet& dbset,
-                                    const CTransaction& tx) = 0;
+    virtual void AcceptToMemoryPool(DatabaseSet& dbset, const CTransaction& tx) = 0;
+    virtual void RemoveFromMemoryPool(const CTransaction& tx) = 0;
 
     /* These are for display and wallet management purposes.  Not for use to decide
      * whether to spend a coin. */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -492,6 +492,8 @@ bool CTransaction::AddToMemoryPoolUnchecked()
 
 bool CTransaction::RemoveFromMemoryPool()
 {
+    hooks->RemoveFromMemoryPool(*this);
+
     // Remove transaction from memory pool
     CRITICAL_BLOCK(cs_mapTransactions)
     {

--- a/src/namecoin.cpp
+++ b/src/namecoin.cpp
@@ -75,6 +75,7 @@ public:
     virtual int LockinHeight();
     virtual string IrcPrefix();
     virtual void AcceptToMemoryPool(DatabaseSet& dbset, const CTransaction& tx);
+    virtual void RemoveFromMemoryPool(const CTransaction& tx);
 
     virtual void MessageStart(char* pchMessageStart)
     {
@@ -1913,7 +1914,7 @@ bool DecodeNameTx(const CTransaction& tx, int& op, int& nOut, vector<vector<unsi
     }
     else
     {
-        // Name bug: before hard-fork point, we reproduce the buggy behavior
+        // Name bug: before the hard-fork point, we reproduce the buggy behavior
         // of concatenating args (vvchPrevArgs not cleared between calls)
         bool fBug = false;
         for (int i = 0; i < tx.vout.size(); i++)
@@ -2075,11 +2076,36 @@ CNamecoinHooks::AcceptToMemoryPool (DatabaseSet& dbset, const CTransaction& tx)
         return;
     }
 
-    CRITICAL_BLOCK(cs_main)
+    if (op != OP_NAME_NEW)
     {
-        if (op != OP_NAME_NEW)
-        {
+        CRITICAL_BLOCK(cs_main)
             mapNamePending[vvch[0]].insert(tx.GetHash());
+    }
+}
+
+void CNamecoinHooks::RemoveFromMemoryPool(const CTransaction& tx)
+{
+    if (tx.nVersion != NAMECOIN_TX_VERSION)
+        return;
+
+    if (tx.vout.size() < 1)
+        return;
+
+    vector<vector<unsigned char> > vvch;
+
+    int op;
+    int nOut;
+
+    if (!DecodeNameTx(tx, op, nOut, vvch, BUG_WORKAROUND_BLOCK))
+        return;
+
+    if (op != OP_NAME_NEW)
+    {
+        CRITICAL_BLOCK(cs_main)
+        {
+            std::map<std::vector<unsigned char>, std::set<uint256> >::iterator mi = mapNamePending.find(vvch[0]);
+            if (mi != mapNamePending.end())
+                mi->second.erase(tx.GetHash());
         }
     }
 }
@@ -2273,7 +2299,7 @@ CNamecoinHooks::ConnectInputs (DatabaseSet& dbset,
                     else
                     {
                         // Accept bad transactions before the hard-fork point, but do not write them to name DB
-                        printf("ConnectInputsHook() : name_firstupdate mismatch bug workaround");
+                        printf("ConnectInputsHook() : name_firstupdate mismatch bug workaround\n");
                         fBugWorkaround = true;
                     }
                 }
@@ -2395,7 +2421,6 @@ CNamecoinHooks::ConnectInputs (DatabaseSet& dbset,
                       return error("ConnectInputsHook() : failed to write to name DB");
                 }
             }
-
 
             if (op != OP_NAME_NEW)
                 CRITICAL_BLOCK(cs_main)


### PR DESCRIPTION
RemoveFromMemoryPool - fixed handling of pending names when reorganizing the block chain
2ecd6df436861d23692550e739c6f5b5bf3f83c3
