### PR TITLE
Fix compilation error in Ubuntu 14.04.

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -5,6 +5,7 @@
 #include "headers.h"
 #include "db.h"
 #include "net.h"
+#include "auxpow.h"
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 


### PR DESCRIPTION
Fix a compilation error in Ubuntu 14.04 - see https://github.com/chronokings/huntercoin/pull/50.  I've tested that the code still works / compiles for me (and the added #include shouldn't hurt), but I can't confirm that it does indeed fix the problem also for Namecoin.  Please, someone test this.  I got reports that the current HEAD fails to build on Ubuntu 14.04 with the same error that appears in Huntercoin.
