### PR TITLE
add more info to the getblock rpc call

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+* New RPC block info: height, confirmations, chainwork, nextblockhash. Change: No previousblockhash for block 0 (RyanC)
+
 v0.3.75
 =======
 * Add difficulty to RPC block output JSON (Domob)


### PR DESCRIPTION
This updates namecoin's getblock RPC call to return everything bitcoin's does except for chainwork.
