### PR TITLE
Custom wallet filename option

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -842,7 +842,7 @@ void ThreadFlushWalletDB(void* parg)
                     if (mi != mapFileUseCount.end())
                     {
                         printf("%s ", DateTimeStrFormat("%x %H:%M:%S", GetTime()).c_str());
-                        printf("Flushing %s\n", walletPath);
+                        printf("Flushing %s\n", walletPath.c_str());
                         nLastFlushed = nWalletDBUpdated;
                         int64 nStart = GetTimeMillis();
 
@@ -852,7 +852,7 @@ void ThreadFlushWalletDB(void* parg)
                         dbenv.lsn_reset(strFile.c_str(), 0);
 
                         mapFileUseCount.erase(mi++);
-                        printf("Flushed %s %"PRI64d"ms\n", walletPath, GetTimeMillis() - nStart);
+                        printf("Flushed %s %"PRI64d"ms\n", walletPath.c_str(), GetTimeMillis() - nStart);
                     }
                 }
             }
@@ -888,11 +888,11 @@ bool BackupWallet(const CWallet& wallet, const string& strDest)
 #else
                     filesystem::copy_file(pathSrc, pathDest);
 #endif
-                    printf("copied %s to %s\n", walletPath, pathDest.string().c_str());
+                    printf("copied %s to %s\n", walletPath.c_str(), pathDest.string().c_str());
 
                     return true;
                 } catch(const filesystem::filesystem_error &e) {
-                    printf("error copying %s to %s - %s\n", walletPath, pathDest.string().c_str(), e.what());
+                    printf("error copying %s to %s - %s\n", walletPath.c_str(), pathDest.string().c_str(), e.what());
                     return false;
                 }
             }

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -5,6 +5,7 @@
 #include "headers.h"
 #include "db.h"
 #include "net.h"
+#include "init.h"
 #include "auxpow.h"
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
@@ -147,12 +148,12 @@ CDB::Close ()
   if (!fReadOnly)
     {
       /* Flush database activity from memory pool to disk log.
-         wallet.dat is always flushed, the other files only every couple
+         wallet file is always flushed, the other files only every couple
          of minutes.
          Note: Namecoin has more .dat files than Bitcoin.  */
 
       unsigned int nMinutes = 2;
-      if (strFile == "wallet.dat")
+      if (strFile == walletPath)
         nMinutes = 0;
       else if ((strFile == "blkindex.dat" || strFile == "nameindex.dat")
                && IsInitialBlockDownload ())
@@ -841,17 +842,17 @@ void ThreadFlushWalletDB(void* parg)
                     if (mi != mapFileUseCount.end())
                     {
                         printf("%s ", DateTimeStrFormat("%x %H:%M:%S", GetTime()).c_str());
-                        printf("Flushing wallet.dat\n");
+                        printf("Flushing %s\n", walletPath);
                         nLastFlushed = nWalletDBUpdated;
                         int64 nStart = GetTimeMillis();
 
-                        // Flush wallet.dat so it's self contained
+                        // Flush wallet file so it's self contained
                         CloseDb(strFile);
                         dbenv.txn_checkpoint(0, 0, 0);
                         dbenv.lsn_reset(strFile.c_str(), 0);
 
                         mapFileUseCount.erase(mi++);
-                        printf("Flushed wallet.dat %"PRI64d"ms\n", GetTimeMillis() - nStart);
+                        printf("Flushed %s %"PRI64d"ms\n", walletPath, GetTimeMillis() - nStart);
                     }
                 }
             }
@@ -875,7 +876,7 @@ bool BackupWallet(const CWallet& wallet, const string& strDest)
                 dbenv.lsn_reset(wallet.strWalletFile.c_str(), 0);
                 mapFileUseCount.erase(wallet.strWalletFile);
 
-                // Copy wallet.dat
+                // Copy wallet file
                 filesystem::path pathSrc(GetDataDir() + "/" + wallet.strWalletFile);
                 filesystem::path pathDest(strDest);
                 if (filesystem::is_directory(pathDest))
@@ -887,11 +888,11 @@ bool BackupWallet(const CWallet& wallet, const string& strDest)
 #else
                     filesystem::copy_file(pathSrc, pathDest);
 #endif
-                    printf("copied wallet.dat to %s\n", pathDest.string().c_str());
+                    printf("copied %s to %s\n", walletPath, pathDest.string().c_str());
 
                     return true;
                 } catch(const filesystem::filesystem_error &e) {
-                    printf("error copying wallet.dat to %s - %s\n", pathDest.string().c_str(), e.what());
+                    printf("error copying %s to %s - %s\n", walletPath, pathDest.string().c_str(), e.what());
                     return false;
                 }
             }

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -877,7 +877,9 @@ bool BackupWallet(const CWallet& wallet, const string& strDest)
                 mapFileUseCount.erase(wallet.strWalletFile);
 
                 // Copy wallet file
-                filesystem::path pathSrc(GetDataDir() + "/" + wallet.strWalletFile);
+                filesystem::path pathSrc(wallet.strWalletFile);
+                if(!pathSrc.is_complete())
+                    pathSrc = filesystem::path(GetDataDir()) / pathSrc;
                 filesystem::path pathDest(strDest);
                 if (filesystem::is_directory(pathDest))
                     pathDest = pathDest / wallet.strWalletFile;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -17,7 +17,7 @@ using namespace boost;
 void rescanfornames();
 
 CWallet* pwalletMain;
-char *walletPath = "";
+string walletPath;
 
 //////////////////////////////////////////////////////////////////////////////
 //
@@ -409,18 +409,12 @@ bool AppInit2(int argc, char* argv[])
     bool fFirstRun;
     string argWalletPath = GetArg("-walletpath", "wallet.dat");
     boost::filesystem::path pathWalletFile(argWalletPath);
-    if (!pathWalletFile.is_complete())pathWalletFile = boost::filesystem::path(GetDataDir()) / pathWalletFile;
-    walletPath = new char[pathWalletFile.string().size() + 1];
-    strcpy(walletPath, pathWalletFile.string().c_str());
+    walletPath = pathWalletFile.string();
     
     pwalletMain = new CWallet(walletPath);
     if (!pwalletMain->LoadWallet(fFirstRun))
-    {
-        if(argWalletPath=="wallet.dat")
-            strErrors += _("Error loading wallet.dat      \n");
-        else
-            strErrors += "Error loading " + argWalletPath + "      \n";
-    }
+      strErrors += "Error loading " + argWalletPath + "      \n";
+    
     printf(" wallet      %15"PRI64d"ms\n", GetTimeMillis() - nStart);
 
     RegisterWallet(pwalletMain);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -17,6 +17,7 @@ using namespace boost;
 void rescanfornames();
 
 CWallet* pwalletMain;
+char *walletPath = "";
 
 //////////////////////////////////////////////////////////////////////////////
 //
@@ -406,9 +407,20 @@ bool AppInit2(int argc, char* argv[])
     printf("Loading wallet...\n");
     nStart = GetTimeMillis();
     bool fFirstRun;
-    pwalletMain = new CWallet("wallet.dat");
+    string argWalletPath = GetArg("-walletpath", "wallet.dat");
+    boost::filesystem::path pathWalletFile(argWalletPath);
+    if (!pathWalletFile.is_complete())pathWalletFile = boost::filesystem::path(GetDataDir()) / pathWalletFile;
+    walletPath = new char[pathWalletFile.string().size() + 1];
+    strcpy(walletPath, pathWalletFile.string().c_str());
+    
+    pwalletMain = new CWallet(walletPath);
     if (!pwalletMain->LoadWallet(fFirstRun))
-        strErrors += _("Error loading wallet.dat      \n");
+    {
+        if(argWalletPath=="wallet.dat")
+            strErrors += _("Error loading wallet.dat      \n");
+        else
+            strErrors += "Error loading " + argWalletPath + "      \n";
+    }
     printf(" wallet      %15"PRI64d"ms\n", GetTimeMillis() - nStart);
 
     RegisterWallet(pwalletMain);
@@ -433,7 +445,7 @@ bool AppInit2(int argc, char* argv[])
         pindexRescan = pindexGenesisBlock;
     else
     {
-        CWalletDB walletdb("wallet.dat");
+        CWalletDB walletdb(walletPath);
         CBlockLocator locator;
         if (walletdb.ReadBestBlock(locator))
             pindexRescan = locator.GetBlockIndex();
@@ -594,6 +606,7 @@ std::string HelpMessage()
     std::string strUsage = std::string(_("Options:\n")) +
         "  -conf=<file>     \t\t  " + _("Specify configuration file (default: namecoin.conf)\n") +
         "  -pid=<file>      \t\t  " + _("Specify pid file (default: namecoind.pid)\n") +
+        "  -walletpath=<file> \t  " + _("Specify the wallet filename (default: wallet.dat)") + "\n" +
         "  -gen             \t\t  " + _("Generate coins\n") +
         "  -gen=0           \t\t  " + _("Don't generate coins\n") +
         "  -min             \t\t  " + _("Start minimized\n") +

--- a/src/init.h
+++ b/src/init.h
@@ -5,7 +5,7 @@
 #define BITCOIN_INIT_H
 
 extern CWallet* pwalletMain;
-extern char *walletPath;
+extern std::string walletPath;
 
 void StartShutdown();
 void Shutdown(void* parg);

--- a/src/init.h
+++ b/src/init.h
@@ -5,6 +5,7 @@
 #define BITCOIN_INIT_H
 
 extern CWallet* pwalletMain;
+extern char *walletPath;
 
 void StartShutdown();
 void Shutdown(void* parg);

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -185,7 +185,7 @@ bool CWalletDB::LoadWallet(CWallet* pwallet)
                 wtx.pwallet = pwallet;
 
                 if (wtx.GetHash() != hash)
-                    printf("Error in %s, hash mismatch\n", walletPath);
+                    printf("Error in %s, hash mismatch\n", walletPath.c_str());
 
                 // Undo serialize changes in 31600
                 if (31404 <= wtx.fTimeReceivedIsTxTime && wtx.fTimeReceivedIsTxTime <= 31703)

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -5,6 +5,7 @@
 
 #include "headers.h"
 #include "db.h"
+#include "init.h"
 #include "wallet.h"
 #include <boost/filesystem.hpp>
 
@@ -184,7 +185,7 @@ bool CWalletDB::LoadWallet(CWallet* pwallet)
                 wtx.pwallet = pwallet;
 
                 if (wtx.GetHash() != hash)
-                    printf("Error in wallet.dat, hash mismatch\n");
+                    printf("Error in %s, hash mismatch\n", walletPath);
 
                 // Undo serialize changes in 31600
                 if (31404 <= wtx.fTimeReceivedIsTxTime && wtx.fTimeReceivedIsTxTime <= 31703)


### PR DESCRIPTION
You can set walletpath=(file) in bitcoin.conf to use a custom wallet file. It doesn't have to be in the data directory, absolute and relative paths are supported too.

Implements feature request #78
