### PR TITLE
Implement "sendtoname" in Qt UI

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 * New command line / .conf file option: -walletpath=customwalletfilename.dat (digital-dreamer)
+* "Pay To" in the Qt can be used to send coins also to a name, like "sendtoname" (Domob)
 * New RPC block info: height, confirmations, chainwork, nextblockhash. Change: No previousblockhash for block 0 (RyanC)
 
 v0.3.75

--- a/namecoin-qt.pro
+++ b/namecoin-qt.pro
@@ -114,7 +114,10 @@ contains(BITCOIN_NEED_QT_PLUGINS, 1) {
     }
 }
 
-QMAKE_CXXFLAGS_WARN_ON = -fdiagnostics-show-option -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter -Wstack-protector -Wno-sign-compare -Wno-return-type -Wno-char-subscripts -Wno-switch
+QMAKE_CXXFLAGS_WARN_ON = -fdiagnostics-show-option -Wall -Wextra \
+  -Wformat -Wformat-security -Wno-unused-parameter -Wstack-protector \
+  -Wno-sign-compare -Wno-return-type -Wno-char-subscripts -Wno-switch \
+  -Wno-unused-value -Wno-unknown-pragmas -Wno-unused-variable
 
 # Input
 DEPENDPATH += src src/json src/cryptopp src/qt

--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -73,7 +73,7 @@
      <item>
       <widget class="QValidatedLineEdit" name="payTo">
        <property name="toolTip">
-        <string>The address to send the payment to (e.g. N1KHAL5C1CRzy58NdJwp1tbLze3XrkFxx9)</string>
+        <string>The address or name to send the payment to (e.g. N1KHAL5C1CRzy58NdJwp1tbLze3XrkFxx9)</string>
        </property>
        <property name="maxLength">
         <number>34</number>

--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -73,7 +73,7 @@
      <item>
       <widget class="QValidatedLineEdit" name="payTo">
        <property name="toolTip">
-        <string>The address or name to send the payment to (e.g. N1KHAL5C1CRzy58NdJwp1tbLze3XrkFxx9)</string>
+        <string>The address or name to send the payment to (e.g. N1KHAL5C1CRzy58NdJwp1tbLze3XrkFxx9 or id/namecoin)</string>
        </property>
        <property name="maxLength">
         <number>34</number>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -89,7 +89,7 @@ bool parseBitcoinURI(const QUrl &uri, SendCoinsRecipient *out)
         return false;
 
     SendCoinsRecipient rv;
-    rv.address = uri.path();
+    rv.recipient = uri.path();
     rv.amount = 0;
 #if QT_VERSION < 0x050000
     QList<QPair<QString, QString> > items = uri.queryItems();

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -95,10 +95,21 @@ void SendCoinsDialog::on_sendButton_clicked()
     QStringList formatted;
     foreach(const SendCoinsRecipient &rcp, recipients)
     {
+        QString addrOrName;
+        if (model->validateAddress (rcp.recipient))
+          addrOrName = rcp.recipient;
+        else
+          {
+            QString address;
+            if (!model->checkRecipientName (rcp.recipient, address))
+              return;
+            addrOrName = QString("%1: %2").arg (rcp.recipient, address);
+          }
+
 #if QT_VERSION < 0x050000
-        formatted.append(tr("<b>%1</b> to %2 (%3)").arg(BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, rcp.amount), Qt::escape(rcp.label), rcp.address));
+        formatted.append(tr("<b>%1</b> to %2 (%3)").arg(BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, rcp.amount), Qt::escape(rcp.label), addrOrName));
 #else
-        formatted.append(tr("<b>%1</b> to %2 (%3)").arg(BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, rcp.amount), rcp.label.toHtmlEscaped(), rcp.address));
+        formatted.append(tr("<b>%1</b> to %2 (%3)").arg(BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, rcp.amount), rcp.label.toHtmlEscaped(), addrOrName));
 #endif
     }
 
@@ -300,7 +311,7 @@ bool SendCoinsDialog::handleURI(const QString &uri)
     // URI has to be valid
     if (GUIUtil::parseBitcoinURI(uri, &rv))
     {
-        CBitcoinAddress address(rv.address.toStdString());
+        CBitcoinAddress address(rv.recipient.toStdString());
         if (!address.IsValid())
             return false;
         pasteEntry(rv);

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -24,7 +24,7 @@ SendCoinsEntry::SendCoinsEntry(QWidget *parent) :
 #if QT_VERSION >= 0x040700
     /* Do not move this to the XML file, Qt before 4.7 will choke on it */
     ui->addAsLabel->setPlaceholderText(tr("Enter a label for this address to add it to your address book"));
-    ui->payTo->setPlaceholderText(tr("Enter a Namecoin address or name (e.g. N1KHAL5C1CRzy58NdJwp1tbLze3XrkFxx9)"));
+    ui->payTo->setPlaceholderText(tr("Enter a Namecoin address or name (e.g. N1KHAL5C1CRzy58NdJwp1tbLze3XrkFxx9 or id/namecoin)"));
 #endif
     setFocusPolicy(Qt::TabFocus);
     setFocusProxy(ui->payTo);

--- a/src/qt/sendcoinsentry.h
+++ b/src/qt/sendcoinsentry.h
@@ -43,7 +43,7 @@ signals:
 
 private slots:
     void on_deleteButton_clicked();
-    void on_payTo_textChanged(const QString &address);
+    void on_payTo_textChanged (const QString& value);
     void on_addressBookButton_clicked();
     void on_pasteButton_clicked();
     void updateDisplayUnit();

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -18,6 +18,18 @@
 std::map<std::vector<unsigned char>, PreparedNameFirstUpdate> mapMyNameFirstUpdate;
 std::map<uint160, std::vector<unsigned char> > mapMyNameHashes;
 
+QString
+SendCoinsRecipient::getAddress (const WalletModel& model) const
+{
+  if (model.validateAddress (recipient))
+    return recipient;
+
+  QString address;
+  if (!model.checkRecipientName (recipient, address))
+    address = "";
+  return address;
+}
+
 WalletModel::WalletModel(CWallet *wallet, OptionsModel *optionsModel, QObject *parent) :
     QObject(parent), wallet(wallet), optionsModel(optionsModel), addressTableModel(0),
     nameTableModel(0), transactionTableModel(0),
@@ -343,10 +355,36 @@ void WalletModel::updateAddressBook(const QString &address, const QString &label
         addressTableModel->updateEntry(address, label, isMine, status);
 }
 
-bool WalletModel::validateAddress(const QString &address)
+bool
+WalletModel::validateAddress(const QString& address) const
 {
     CBitcoinAddress addressParsed(address.toStdString());
     return addressParsed.IsValid();
+}
+
+bool
+WalletModel::checkRecipientName (const QString& name, QString& address) const
+{
+  /* To prevent "typo-squatting" for addresses, only allow names
+     up to a certain length (shorter than NMC addresses).  */
+  if (name.length () < 1 || name.length () > 25)
+    return false;
+
+  const vchType vchName = vchFromString (name.toStdString ());
+  CNameDB dbName("r");
+  if (!dbName.ExistsName (vchName))
+    return false;
+
+  CTransaction tx;
+  if (!GetTxOfName (dbName, vchName, tx))
+    return false;
+
+  std::string addr;
+  if (!GetNameAddress (tx, addr))
+    return false;
+
+  address = QString::fromStdString (addr);
+  return true;
 }
 
 WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipient> &recipients)
@@ -363,11 +401,10 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
     // Pre-check input data for validity
     foreach(const SendCoinsRecipient &rcp, recipients)
     {
-        if(!validateAddress(rcp.address))
-        {
-            return InvalidAddress;
-        }
-        setAddress.insert(rcp.address);
+        const QString address = rcp.getAddress (*this);
+        if (address == "")
+          return InvalidAddress;
+        setAddress.insert (address);
 
         if(rcp.amount <= 0)
         {
@@ -398,8 +435,12 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
         std::vector<std::pair<CScript, int64> > vecSend;
         foreach(const SendCoinsRecipient &rcp, recipients)
         {
+            const std::string addr = rcp.getAddress (*this).toStdString ();
+            const CBitcoinAddress parsedAddr(addr);
+
             CScript scriptPubKey;
-            scriptPubKey.SetDestination(CBitcoinAddress(rcp.address.toStdString()).Get());
+            scriptPubKey.SetDestination (parsedAddr.Get ());
+
             vecSend.push_back(std::make_pair(scriptPubKey, rcp.amount));
         }
 
@@ -430,7 +471,7 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
     // Add addresses / update labels that we've sent to to the address book
     foreach(const SendCoinsRecipient &rcp, recipients)
     {
-        std::string strAddress = rcp.address.toStdString();
+        const std::string strAddress = rcp.getAddress (*this).toStdString ();
         CTxDestination dest = CBitcoinAddress(strAddress).Get();
         std::string strLabel = rcp.label.toStdString();
         {

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -368,7 +368,7 @@ bool
 WalletModel::checkRecipientName (const QString& name, QString& address) const
 {
   /* Check that the name contains a namespace and consists only of
-     basic characters (a-z, 0-9, - and space).  This is to prevent
+     basic characters (a-z, 0-9 and dash).  This is to prevent
      tricking people into sending to other names than they intend, and
      to prevent squatting of the "no namespace" names.
 
@@ -376,7 +376,7 @@ WalletModel::checkRecipientName (const QString& name, QString& address) const
      have a namespace and contain upper case characters (most probably).  */
 
   using namespace boost::xpressive;
-  static const char* regexStr = "^[a-z]+/[a-z0-9-]?([ ]?[a-z0-9-])*$";
+  static const char* regexStr = "^[a-z]+/[a-z0-9]+([-]?[a-z0-9])*$";
   static const sregex regex = sregex::compile (regexStr);
   smatch match;
   if (!regex_search (name.toStdString (), match, regex))

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -10,6 +10,7 @@ class OptionsModel;
 class AddressTableModel;
 class NameTableModel;
 class TransactionTableModel;
+class WalletModel;
 class CWallet;
 class CWalletTx;
 
@@ -20,9 +21,14 @@ QT_END_NAMESPACE
 class SendCoinsRecipient
 {
 public:
-    QString address;
+    QString recipient;
     QString label;
     qint64 amount;
+
+    /* Get the recipient address.  This translates a recipient name if
+       applicable.  Returns "" if the value is not a valid address and also
+       not resolvable as name.  */
+    QString getAddress (const WalletModel& model) const;
 };
 
 /** Interface to Bitcoin wallet from Qt view code. */
@@ -66,7 +72,11 @@ public:
     EncryptionStatus getEncryptionStatus() const;
 
     // Check address for validity
-    bool validateAddress(const QString &address);
+    bool validateAddress (const QString& address) const;
+
+    /* Check if a given name can be used as a "sendtoname" recipient and
+       if yes, set the address to the use that should be used.  */
+    bool checkRecipientName (const QString& name, QString& address) const;
 
     // Return status record for SendCoins, contains error id + information
     struct SendCoinsReturn


### PR DESCRIPTION
This patch implements an equivalent of the "sendtoname" functionality in the Qt UI.  You can now enter a name in the "Pay To" field, and have the coins sent to the address holding the name.  This only works if the name is not expired and 1-25 characters long.  The latter constraint is to prevent "typo squatting" on Namecoin addresses.

This may make live easier for "ordinary users" who don't like the cryptic addresses - and it can be used to tip websites or identities.
