### PR TITLE
Implement "daemon warmup" for the RPC interface.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 * New command line / .conf file option: -walletpath=customwalletfilename.dat (digital-dreamer)
 * "Pay To" in the Qt can be used to send coins also to a name, like "sendtoname" (Domob)
 * New RPC block info: height, confirmations, chainwork, nextblockhash. Change: No previousblockhash for block 0 (RyanC)
+* The RPC interface now returns an error while initialising, instead of not accepting connections at all (Domob)
 
 v0.3.75
 =======

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -47,6 +47,8 @@ using namespace boost;
 using namespace boost::asio;
 using namespace json_spirit;
 
+const char* rpcWarmupStatus = "uninitialised";
+
 void ThreadRPCServer2(void* parg);
 Value sendtoaddress(const Array& params, bool fHelp);
 
@@ -4056,6 +4058,10 @@ void ThreadRPCServer2(void* parg)
 
             // Parse id now so errors from here on will have the id
             id = find_value(request, "id");
+
+            // Bail early if not yet initialised.
+            if (rpcWarmupStatus)
+              throw JSONRPCError (RPC_IN_WARMUP, rpcWarmupStatus);
 
             // Parse method
             Value valMethod = find_value(request, "method");

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -78,6 +78,13 @@ enum RPCErrorCode
 
     // Async method call interrupted.
     RPC_ASYNC_INTERRUPT             = -100,
+    // Daemon in warm-up phase.
+    RPC_IN_WARMUP                   = -101,
 };
+
+/* Keep track of current "warmup status".  This is set to a descriptive
+   string while initialising everything, and NULL if the RPC process
+   can function as normal.  */
+extern const char* rpcWarmupStatus;
 
 #endif

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -367,6 +367,14 @@ bool AppInit2(int argc, char* argv[])
     strErrors = "";
     int64 nStart;
 
+    /* Start the RPC server already here.  This is to make it available
+       "immediately" upon starting the daemon process.  Until everything
+       is initialised, it will always just return a "status error" and
+       not try to access the uninitialised stuff.  */
+    if (fServer)
+        CreateThread(ThreadRPCServer, NULL);
+
+    rpcWarmupStatus = "loading addresses";
     printf("Loading addresses...\n");
     nStart = GetTimeMillis();
     if (!LoadAddresses())
@@ -398,12 +406,14 @@ bool AppInit2(int argc, char* argv[])
       CNameDB dbName("cr+");
     }
 
+    rpcWarmupStatus = "loading block index";
     printf("Loading block index...\n");
     nStart = GetTimeMillis();
     if (!LoadBlockIndex())
         strErrors += _("Error loading blkindex.dat      \n");
     printf(" block index %15"PRI64d"ms\n", GetTimeMillis() - nStart);
 
+    rpcWarmupStatus = "loading wallet";
     printf("Loading wallet...\n");
     nStart = GetTimeMillis();
     bool fFirstRun;
@@ -421,8 +431,11 @@ bool AppInit2(int argc, char* argv[])
 
     /* Rescan for name index now if we need to do it.  */
     if (needNameRescan)
-      rescanfornames ();
-
+      {
+        rpcWarmupStatus = "rescanning for names";
+        rescanfornames ();
+      }
+    
     // Read -mininput before -rescan, otherwise rescan will skip transactions
     // lower than the default mininput
     if (mapArgs.count("-mininput"))
@@ -434,6 +447,7 @@ bool AppInit2(int argc, char* argv[])
         }
     }
 
+    rpcWarmupStatus = "rescanning blockchain";
     CBlockIndex *pindexRescan = pindexBest;
     if (GetBoolArg("-rescan"))
         pindexRescan = pindexGenesisBlock;
@@ -470,6 +484,7 @@ bool AppInit2(int argc, char* argv[])
     }
 
     // Add wallet transactions that aren't already in a block to mapTransactions
+    rpcWarmupStatus = "reaccept wallet transactions";
     pwalletMain->ReacceptWalletTransactions();
 
     //
@@ -578,8 +593,9 @@ bool AppInit2(int argc, char* argv[])
     if (!CreateThread(StartNode, NULL))
         wxMessageBox("Error: CreateThread(StartNode) failed", "Namecoin");
 
-    if (fServer)
-        CreateThread(ThreadRPCServer, NULL);
+    /* We're done initialising, from now on, the RPC daemon
+       can work as usual.  */
+    rpcWarmupStatus = NULL;
 
 #if defined(__WXMSW__) && defined(GUI)
     if (fFirstRun)


### PR DESCRIPTION
Port from Huntercoin:

Fix https://github.com/chronokings/huntercoin/issues/63 by starting the
RPC daemon early during start up.  Until everything necessary is
initialised, it simply returns an error early on when called.
