### PR TITLE
Block ancient dust spam

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1191,9 +1191,11 @@ CTransaction::ConnectInputs (DatabaseSet& dbset,
 
             /* Check for unspendable outputs.  This is redundant for some
                of the checks done in IsUnspendable, but it also takes care
-               of blocking dust spam.  */
+               of blocking dust spam.  If not validating blocks (i. e., miner
+               or mempool), we are strict and block dust even before
+               the hardfork point.  */
             if (IsUnspendable (txPrev->vout[prevout.n], prevHeight,
-                               pindexBlock->nHeight))
+                               pindexBlock->nHeight, !fBlock))
               return error ("ConnectInputs: previous txo is unspendable");
 
             // If prev is coinbase, check that it's matured

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1164,6 +1164,15 @@ CTransaction::ConnectInputs (DatabaseSet& dbset,
             assert (vin[i].fHasPrevInfo);
             assert (txPrev);
 
+            /* Calculate the previous output's height.  Note that the value
+               here should be ensured to be accurate, since IsUnspendable
+               below depends on it for block validation!  Thus we do not
+               use the cache introduced for priority calculation.  */
+            int prevHeight = txindex.GetHeight ();
+            if (prevHeight == -1)
+              prevHeight = pindexBlock->nHeight;
+            assert (prevHeight >= 0);
+
             if (prevout.n >= txPrev->vout.size ())
               return error ("ConnectInputs: %s prevout.n out of range"
                             " %d %d prev tx %s\n%s",
@@ -1179,6 +1188,13 @@ CTransaction::ConnectInputs (DatabaseSet& dbset,
                 && !VerifySignature (*txPrev, *this, i))
               return error ("ConnectInputs: %s VerifySignature failed",
                             GetHash ().ToString ().substr (0, 10).c_str ());
+
+            /* Check for unspendable outputs.  This is redundant for some
+               of the checks done in IsUnspendable, but it also takes care
+               of blocking dust spam.  */
+            if (IsUnspendable (txPrev->vout[prevout.n], prevHeight,
+                               pindexBlock->nHeight))
+              return error ("ConnectInputs: previous txo is unspendable");
 
             // If prev is coinbase, check that it's matured
             if (txPrev->IsCoinBase ())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -642,7 +642,7 @@ CTxIndex::GetContainingBlock (const CDiskTxPos& pos)
 
     // Read block header
     CBlock block;
-    if (!block.ReadFromDisk(pos.nFile, pos.nBlockPos, false))
+    if (!block.ReadFromDisk (pos.nFile, pos.nBlockPos, false))
         return NULL;
 
     // Find the block in the index

--- a/src/main.h
+++ b/src/main.h
@@ -110,6 +110,7 @@ extern CHooks* hooks;
 class CReserveKey;
 class CTxDB;
 class CTxIndex;
+class CTxOut;
 
 void RegisterWallet(CWallet* pwalletIn);
 void UnregisterWallet(CWallet* pwalletIn);
@@ -141,6 +142,11 @@ std::string GetWarnings(std::string strFor);
 /** Retrieve a transaction (from memory pool, or from disk, if possible) */
 bool GetTransaction(const uint256 &hash, CTransaction &txOut, uint256 &hashBlock /*, bool fAllowSlow = false*/  );
 
+/* Check if a transaction is unspendable.  Either because it is provably
+   prunable, or because it is explicitly blocked due to some rule.  nHeight
+   is the height at which (or later) it will be spent, and nPrevHeight
+   is the one where it is included in the block chain.  */
+bool IsUnspendable (const CTxOut& txo, int nPrevHeight, int nHeight);
 
 
 
@@ -942,6 +948,10 @@ public:
     static int GetHeight (const CDiskTxPos& pos);
     static int GetDepthInMainChain (const CDiskTxPos& pos);
 
+    inline int GetHeight () const
+    {
+      return GetHeight (pos);
+    }
     inline int GetDepthInMainChain () const
     {
       return GetDepthInMainChain (pos);

--- a/src/main.h
+++ b/src/main.h
@@ -145,8 +145,11 @@ bool GetTransaction(const uint256 &hash, CTransaction &txOut, uint256 &hashBlock
 /* Check if a transaction is unspendable.  Either because it is provably
    prunable, or because it is explicitly blocked due to some rule.  nHeight
    is the height at which (or later) it will be spent, and nPrevHeight
-   is the one where it is included in the block chain.  */
-bool IsUnspendable (const CTxOut& txo, int nPrevHeight, int nHeight);
+   is the one where it is included in the block chain.  The strict parameter
+   can be turned on for mempool validation (as opposed to blocks) to
+   reject transactions from the mempool even before a hardfork.  */
+bool IsUnspendable (const CTxOut& txo, int nPrevHeight,
+                    int nHeight, bool strict);
 
 
 

--- a/src/namecoin.cpp
+++ b/src/namecoin.cpp
@@ -1937,7 +1937,7 @@ int64 GetNameNetFee(const CTransaction& tx)
 }
 
 bool
-IsUnspendable (const CTxOut& txo, int nPrevHeight, int nHeight)
+IsUnspendable (const CTxOut& txo, int nPrevHeight, int nHeight, bool strict)
 {
   assert (nPrevHeight <= nHeight);
 
@@ -1951,7 +1951,7 @@ IsUnspendable (const CTxOut& txo, int nPrevHeight, int nHeight)
      set.  We block all 1-Swartz outputs created between blocks 39k and 41k.
      Blocking takes effect at the softfork height.  */
   if (txo.nValue == 1 && nPrevHeight >= 39000 && nPrevHeight <= 41000
-      && nHeight >= FORK_HEIGHT_DUSTSPAM)
+      && (strict || nHeight >= FORK_HEIGHT_DUSTSPAM))
     return true;
 
   /* A name_update or name_firstupdate is unspendable if expired.  */


### PR DESCRIPTION
This patch blocks "ancient" dust spam outputs (1 Swartz value, created between blocks 39k and 41k) from being spent in the future (starting at a predefined softfork block height - set to 300k for now until we decide about the actual value).  This enables them to be removed from the UTXO set.  See https://forum.namecoin.info/viewtopic.php?f=2&t=1877.

So far, I've only done rudimentary testing (not verified that the full chain still syncs fine, for instance).  But the proposed solution here is open for discussion.

To test it, you can use a raw tx like this:

`0100000002da11011c1bf3faf601ad8fc9eba9ef34feef0accf1df8590575390735345b8e80000000000ffffffff4b92dec3ce36a750f19b5ec9abfaab97b21b0512e5b8ffce399301adbdc624eb0000000000ffffffff0100e1f505000000001976a9144d92cbd00dc8e35d23329e3e858dc0d2c8f9014088ac00000000`

With `sendrawtransaction`, it will be rejected before and after the patch (since it doesn't have any signatures on it).  However, when the new rule strikes, the debug.log will read "previous txo is unspendable" instead of "signature verification failed" (since the new check comes before signature verification).  Of course, you have to set FORK_HEIGHT_DUSTSPAM to some lower value first to see the effect.
