### PR TITLE
Improve disk fragmentation of block files

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -512,6 +512,29 @@ bool CTxDB::WriteBestInvalidWork(CBigNum bnBestInvalidWork)
     return Write(string("bnBestInvalidWork"), bnBestInvalidWork);
 }
 
+unsigned
+CTxDB::ReadBlockFileReserved (unsigned num)
+{
+  const std::pair<std::string, unsigned> key("blkreserved", num);
+  if (!Exists (key))
+    return 0;
+
+  unsigned res;
+  if (!Read (key, res))
+    {
+      printf ("ERROR: ReadBlockFileReserved: reading the DB failed\n");
+      return 0;
+    }
+  return res;
+}
+
+bool
+CTxDB::WriteBlockFileReserved (unsigned num, unsigned size)
+{
+  const std::pair<std::string, unsigned> key("blkreserved", num);
+  return Write (key, size);
+}
+
 CBlockIndex static * InsertBlockIndex(uint256 hash)
 {
     if (hash == 0)

--- a/src/db.h
+++ b/src/db.h
@@ -355,6 +355,12 @@ public:
     bool WriteHashBestChain(uint256 hashBestChain);
     bool ReadBestInvalidWork(CBigNum& bnBestInvalidWork);
     bool WriteBestInvalidWork(CBigNum bnBestInvalidWork);
+
+    /* Read/write number of "reserved" (but not yet used) bytes in the
+       block files.  */
+    unsigned ReadBlockFileReserved (unsigned num);
+    bool WriteBlockFileReserved (unsigned num, unsigned size);
+
     bool LoadBlockIndex();
 
     /* Update txindex to new data format.  */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1752,7 +1752,7 @@ bool static ScanMessageStart(Stream& s)
     }
 }
 
-static bool
+bool
 CheckDiskSpace (uint64 nAdditionalBytes)
 {
     uint64 nFreeBytesAvailable = filesystem::space(GetDataDir()).available;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1481,12 +1481,14 @@ int GetOurChainID()
 
 bool CBlock::WriteToDisk(unsigned int& nFileRet, unsigned int& nBlockPosRet)
 {
+    DatabaseSet dbset("r+");
+
     unsigned nSize;
     unsigned nTotalSize = ::GetSerializeSize (*this, SER_DISK);
     nTotalSize += sizeof (pchMessageStart) + sizeof (nSize);
 
     // Open history file to append
-    CAutoFile fileout = AppendBlockFile (nFileRet, nTotalSize);
+    CAutoFile fileout = AppendBlockFile (dbset, nFileRet, nTotalSize);
     if (!fileout)
         return error("CBlock::WriteToDisk() : AppendBlockFile failed");
     const unsigned startPos = ftell (fileout);
@@ -1804,9 +1806,9 @@ static unsigned int nCurrentBlockFile = 1;
    bytes that will be written.  This is used to check for disk space as well
    as extend the file in preallocated chunks to combat fragmentation.  */
 FILE*
-AppendBlockFile (unsigned int& nFileRet, unsigned size)
+AppendBlockFile (DatabaseSet& dbset, unsigned int& nFileRet, unsigned size)
 {
-    CTxDB txdb("r+");
+    CTxDB& txdb = dbset.tx ();
 
     if (!CheckDiskSpace (size))
       {

--- a/src/main.h
+++ b/src/main.h
@@ -108,7 +108,8 @@ void SyncWithWallets(const CTransaction& tx, const CBlock* pblock = NULL, bool f
 bool ProcessBlock(CNode* pfrom, CBlock* pblock);
 bool CheckDiskSpace (uint64 nAdditionalBytes = 0);
 FILE* OpenBlockFile(unsigned int nFile, unsigned int nBlockPos, const char* pszMode="rb");
-FILE* AppendBlockFile (unsigned int& nFileRet, unsigned size);
+FILE* AppendBlockFile (DatabaseSet& dbset, unsigned int& nFileRet,
+                       unsigned size);
 void FlushBlockFile(FILE *f);
 bool LoadBlockIndex(bool fAllowNew=true);
 void PrintBlockTree();

--- a/src/main.h
+++ b/src/main.h
@@ -106,6 +106,7 @@ void UnregisterWallet(CWallet* pwalletIn);
 /** Push an updated transaction to all registered wallets */
 void SyncWithWallets(const CTransaction& tx, const CBlock* pblock = NULL, bool fUpdate = false);
 bool ProcessBlock(CNode* pfrom, CBlock* pblock);
+bool CheckDiskSpace (uint64 nAdditionalBytes = 0);
 FILE* OpenBlockFile(unsigned int nFile, unsigned int nBlockPos, const char* pszMode="rb");
 FILE* AppendBlockFile (unsigned int& nFileRet, unsigned size);
 void FlushBlockFile(FILE *f);


### PR DESCRIPTION
This is a port of https://github.com/chronokings/huntercoin/pull/66.  The patch changes adding to the block files (blk????.dat) to be done in chunks of 16 MiB, which decreases file system fragmentation and is (I have heard) a big improvement especially on NTFS systems.

It has been tested already a while in Huntercoin, and I'm running a sync from scratch with this patch applied right now.  It correctly allocates the file in chunks, and is already at block 20k.  So it seems to work - but it would be cool to get more testing results, especially on Windows with NTFS.
