### PR TITLE
fix #142 - proxy settings not loaded

### DIFF
--- a/src/qt/locale/bitcoin_cs.ts
+++ b/src/qt/locale/bitcoin_cs.ts
@@ -1438,7 +1438,7 @@ a po ní zařadí do fronty transakci name_firstupdate.</translation>
     <message>
         <location line="+71"/>
         <source>&amp;OK</source>
-        <translation>&amp;Budiž</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <location line="+7"/>
@@ -1448,7 +1448,7 @@ a po ní zařadí do fronty transakci name_firstupdate.</translation>
     <message>
         <location line="+10"/>
         <source>&amp;Apply</source>
-        <translation>&amp;Uložit</translation>
+        <translation>&amp;Použít</translation>
     </message>
     <message>
         <location filename="../optionsdialog.cpp" line="+53"/>

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -26,6 +26,7 @@ bool static ApplyProxySettings()
     if (!settings.value("fUseProxy", false).toBool()) {
         addrProxy = CService();
         nSocksVersion = 0;
+        SetProxy(NET_IPV4, addrProxy, nSocksVersion);
         return false;
     }
     if (nSocksVersion && !addrProxy.IsValid())
@@ -70,6 +71,7 @@ void OptionsModel::Init()
         SoftSetArg("-socks", settings.value("nSocksVersion").toString().toStdString());
     if (!language.isEmpty())
         SoftSetArg("-lang", language.toStdString());
+    ApplyProxySettings();
 }
 
 void OptionsModel::Reset()


### PR DESCRIPTION
First problem: ApplyProxySettings() was not called on startup, which made the OptionsModel::data say there is no proxy, even if it is on. This causes the options dialog to show proxy as disabled, and if you then save it, it actually disables it.

Solution: Just call ApplyProxySettings() on init.

Second problem: After I fixed this, I found the opposite issue too. If you have proxy enabled, and you disable it in options, hit OK and then go to option again, you still see it as enabled. This was caused by another bug in ApplyProxySettings(). Function returns false before it can call SetProxy to set it to zero.

Solution: Add the missing call to SetProxy.

I also added a clarification of potentially confusing button text meanings in the Czech localization that I noticed while working on this.
