### PR TITLE
Implement name "renew" in Qt

### DIFF
--- a/src/qt/forms/managenamespage.ui
+++ b/src/qt/forms/managenamespage.ui
@@ -242,29 +242,61 @@ to the network and creates a pending name_firstupdate transaction.</string>
       </layout>
      </item>
      <item>
-      <widget class="QPushButton" name="configureNameButton">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <property name="spacing">
+        <number>0</number>
        </property>
-       <property name="minimumSize">
-        <size>
-         <width>150</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string>Configure name and submit update operation</string>
-       </property>
-       <property name="text">
-        <string>&amp;Configure Name...</string>
-       </property>
-       <property name="default">
-        <bool>false</bool>
-       </property>
-      </widget>
+       <item>
+        <widget class="QPushButton" name="configureNameButton">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>150</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Configure name and submit update operation</string>
+         </property>
+         <property name="text">
+          <string>&amp;Configure Name...</string>
+         </property>
+         <property name="default">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="renewNameButton">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>150</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Renew the name with its current value</string>
+         </property>
+         <property name="text">
+          <string>&amp;Renew Name</string>
+         </property>
+         <property name="default">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
     </layout>
    </item>

--- a/src/qt/managenamespage.h
+++ b/src/qt/managenamespage.h
@@ -73,6 +73,7 @@ private slots:
     void onCopyValueAction();
     void onCopyAddressAction();
     void on_configureNameButton_clicked();
+    void on_renewNameButton_clicked();
 };
 
 #endif // MANAGENAMESPAGE_H

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -738,6 +738,28 @@ QString WalletModel::nameUpdate(const QString &name, const QString &data, const 
     }
 }
 
+QString
+WalletModel::nameRenew (const QString& name)
+{
+  const vchType vchName = vchFromString (name.toStdString ());
+
+  vchType vchValue;
+  CRITICAL_BLOCK(cs_main)
+    {
+      CNameDB dbName("r");
+      std::vector<CNameIndex> vNameIndex;
+      if (!dbName.ReadName (vchName, vNameIndex))
+        return tr ("Failed to read from the name DB");
+      if (vNameIndex.empty ())
+        return tr ("No result returned");
+
+      vchValue = vNameIndex.back ().vValue;
+    }
+
+  const std::string strValue = stringFromVch (vchValue);
+  return nameUpdate (name, QString::fromStdString (strValue), "");
+}
+
 OptionsModel *WalletModel::getOptionsModel()
 {
     return optionsModel;

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -121,6 +121,10 @@ public:
     // Requires unlocked wallet; can throw exception instead of returning error
     QString nameUpdate(const QString &name, const QString &data, const QString &transferToAddress);
 
+    /* Renew a name:  Calls nameUpdate internally, but uses the
+       name's current value.  */
+    QString nameRenew (const QString& name);
+
     // Wallet encryption
     bool setWalletEncrypted(bool encrypted, const SecureString &passphrase);
     // Passphrase only needed when unlocking


### PR DESCRIPTION
Fix https://github.com/namecoin/namecoin/issues/131:  This patch implements a "Renew name" UI operation accessible both as new button on the "Manage names" page as well as via the name list context menu.  The operation simply does a name_update with the name's current value, and is thus a "shortcut" to using the "Configure Name..." dialog without changing anything.
