### PR TITLE
Speed up name_list.

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -761,6 +761,17 @@ public:
     int GetDepthInMainChain() const { int nHeight; return GetDepthInMainChain(nHeight); }
     bool IsInMainChain() const { return GetDepthInMainChain() > 0; }
     int GetBlocksToMaturity() const;
+
+    inline int
+    GetHeightInMainChain() const
+    {
+      int nHeight;
+      if (GetDepthInMainChain (nHeight) == 0)
+        return -1;
+
+      return nHeight;
+    }
+
     bool AcceptToMemoryPool (DatabaseSet& dbset, bool fCheckInputs = true);
     bool AcceptToMemoryPool();
 };

--- a/src/namecoin.cpp
+++ b/src/namecoin.cpp
@@ -560,76 +560,55 @@ Value name_list(const Array& params, bool fHelp)
                 "list my own names"
                 );
 
-    vector<unsigned char> vchName;
-    vector<unsigned char> vchLastName;
-    int nMax = 10000000;
-
-    if (params.size() == 1)
-    {
-        vchName = vchFromValue(params[0]);
-        nMax = 1;
-    }
-
-    vector<unsigned char> vchNameUniq;
-    if (params.size() == 1)
-    {
-        vchNameUniq = vchFromValue(params[0]);
-    }
+    vchType vchNameUniq;
+    if (params.size () == 1)
+      vchNameUniq = vchFromValue (params[0]);
 
     Array oRes;
-    map< vector<unsigned char>, int > vNamesI;
-    map< vector<unsigned char>, Object > vNamesO;
+    std::map<vchType, int> vNamesI;
+    std::map<vchType, Object> vNamesO;
 
+    CRITICAL_BLOCK(cs_main)
     CRITICAL_BLOCK(pwalletMain->cs_mapWallet)
-    {
-        CTxIndex txindex;
-        uint256 hash;
+      {
         CTxDB txdb("r");
-        CTransaction tx;
 
-        vector<unsigned char> vchName;
-        vector<unsigned char> vchValue;
-        int nHeight;
+        BOOST_FOREACH(PAIRTYPE(const uint256, CWalletTx)& item,
+                      pwalletMain->mapWallet)
+          {
+            const CWalletTx& tx = item.second;
 
-        BOOST_FOREACH(PAIRTYPE(const uint256, CWalletTx)& item, pwalletMain->mapWallet)
-        {
-            hash = item.second.GetHash();
-            if(!txdb.ReadDiskTx(hash, tx, txindex))
-                continue;
+            vchType vchName, vchValue;
+            int nOut;
+            if (!tx.GetNameUpdate (nOut, vchName, vchValue))
+              continue;
 
-            if (tx.nVersion != NAMECOIN_TX_VERSION)
-                continue;
+            if(!vchNameUniq.empty () && vchNameUniq != vchName)
+              continue;
 
-            // name
-            if(!GetNameOfTx(tx, vchName))
-                continue;
-            if(vchNameUniq.size() > 0 && vchNameUniq != vchName)
-                continue;
+            const int nHeight = tx.GetHeightInMainChain ();
+            if (nHeight == -1)
+              continue;
+            assert (nHeight >= 0);
 
-            // value
-            if(!GetValueOfNameTx(tx, vchValue))
-                continue;
-
-            // height
-            nHeight = GetTxPosHeight(txindex.pos);
+            // get last active name only
+            if (vNamesI.find (vchName) != vNamesI.end ()
+                && vNamesI[vchName] > nHeight)
+              continue;
 
             Object oName;
             oName.push_back(Pair("name", stringFromVch(vchName)));
             oName.push_back(Pair("value", stringFromVch(vchValue)));
-            if (!hooks->IsMine(pwalletMain->mapWallet[tx.GetHash()]))
+            if (!hooks->IsMine (tx))
                 oName.push_back(Pair("transferred", 1));
             string strAddress = "";
             GetNameAddress(tx, strAddress);
             oName.push_back(Pair("address", strAddress));
-            oName.push_back(Pair("expires_in", nHeight + GetDisplayExpirationDepth(nHeight) - pindexBest->nHeight));
-            if(nHeight + GetDisplayExpirationDepth(nHeight) - pindexBest->nHeight <= 0)
-            {
-                oName.push_back(Pair("expired", 1));
-            }
 
-            // get last active name only
-            if(vNamesI.find(vchName) != vNamesI.end() && vNamesI[vchName] > nHeight)
-                continue;
+            const int expiresIn = nHeight + GetDisplayExpirationDepth (nHeight) - pindexBest->nHeight;
+            oName.push_back (Pair("expires_in", expiresIn));
+            if (expiresIn <= 0)
+              oName.push_back (Pair("expired", 1));
 
             vNamesI[vchName] = nHeight;
             vNamesO[vchName] = oName;

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -651,6 +651,51 @@ void CWallet::ResendWalletTransactions()
 
 
 
+bool
+CWalletTx::GetNameUpdate (int& nOut, vchType& nm, vchType& val) const
+{
+  if (nVersion != NAMECOIN_TX_VERSION)
+    return false;
+
+  if (!nameTxDecoded)
+    {
+      nameTxDecoded = true;
+
+      std::vector<vchType> vvch;
+      int op;
+      if (DecodeNameTx (*this, op, nNameOut, vvch, -1))
+        switch (op)
+          {
+          case OP_NAME_FIRSTUPDATE:
+            vchName = vvch[0];
+            vchValue = vvch[2];
+            nameTxDecodeSuccess = true;
+            break;
+
+          case OP_NAME_UPDATE:
+            vchName = vvch[0];
+            vchValue = vvch[1];
+            nameTxDecodeSuccess = true;
+            break;
+
+          case OP_NAME_NEW:
+          default:
+            nameTxDecodeSuccess = false;
+            break;
+          }
+      else
+        nameTxDecodeSuccess = false;
+    }
+
+  if (!nameTxDecodeSuccess)
+    return false;
+
+  nOut = nNameOut;
+  nm = vchName;
+  val = vchValue;
+  return true;
+}
+
 
 
 

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -338,6 +338,14 @@ public:
     mutable bool fImmatureCreditCached;
     mutable int64 nImmatureCreditCached;
 
+    /* For name transactions, cache the decoded info:  Name, value
+       and index out name output.  */
+    mutable bool nameTxDecoded;
+    mutable bool nameTxDecodeSuccess;
+    mutable int nNameOut;
+    mutable vchType vchName;
+    mutable vchType vchValue;
+
     // memory only UI hints
     mutable unsigned int nTimeDisplayed;
     mutable int nLinesDisplayed;
@@ -386,6 +394,11 @@ public:
         nAvailableCreditCached = 0;
         nImmatureCreditCached = 0;
         nChangeCached = 0;
+
+        nameTxDecoded = false;
+        vchName.clear ();
+        vchValue.clear ();
+
         nTimeDisplayed = 0;
         nLinesDisplayed = 0;
         fConfirmedDisplayed = false;
@@ -638,6 +651,11 @@ public:
 
     void RelayWalletTransaction(CTxDB& txdb);
     void RelayWalletTransaction();
+
+    /* Try to decode the tx as a name_(first)update and return true if
+       it works.  In this case, also the info is set in the output
+       arguments.  The result is cached to save CPU time.  */
+    bool GetNameUpdate (int& nOut, vchType& nm, vchType& val) const;
 };
 
 


### PR DESCRIPTION
This replaces the implementation of name_list (and the corresponding Qt code) with a smarter implementation (see also https://github.com/chronokings/huntercoin/pull/76).  The new implementation doesn't use any disk accesses, and is significantly faster for large wallets.
