### PR TITLE
Cache ECDSA signature verifications.

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -303,30 +303,35 @@ public:
     CScript scriptSig;
     unsigned int nSequence;
 
-    CTxIn()
-    {
-        nSequence = UINT_MAX;
-    }
+    /* Only in memory:  Remember when we have already (successfully) checked
+       this txin signature to avoid re-verification.  */
+    mutable bool fChecked;
 
-    explicit CTxIn(COutPoint prevoutIn, CScript scriptSigIn=CScript(), unsigned int nSequenceIn=UINT_MAX)
-    {
-        prevout = prevoutIn;
-        scriptSig = scriptSigIn;
-        nSequence = nSequenceIn;
-    }
+    inline CTxIn ()
+      : nSequence(UINT_MAX), fChecked(false)
+    {}
 
-    CTxIn(uint256 hashPrevTx, unsigned int nOut, CScript scriptSigIn=CScript(), unsigned int nSequenceIn=UINT_MAX)
-    {
-        prevout = COutPoint(hashPrevTx, nOut);
-        scriptSig = scriptSigIn;
-        nSequence = nSequenceIn;
-    }
+    explicit inline CTxIn (COutPoint prevoutIn, CScript scriptSigIn = CScript(),
+                           unsigned int nSequenceIn = UINT_MAX)
+      : prevout(prevoutIn), scriptSig(scriptSigIn), nSequence(nSequenceIn),
+        fChecked(false)
+    {}
+
+    inline CTxIn (uint256 hashPrevTx, unsigned int nOut,
+                  CScript scriptSigIn = CScript(),
+                  unsigned int nSequenceIn = UINT_MAX)
+      : prevout(hashPrevTx, nOut), scriptSig(scriptSigIn),
+        nSequence(nSequenceIn), fChecked(false)
+    {}
 
     IMPLEMENT_SERIALIZE
     (
         READWRITE(prevout);
         READWRITE(scriptSig);
         READWRITE(nSequence);
+
+        if (fRead)
+          fChecked = false;
     )
 
     bool IsFinal() const

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1292,9 +1292,18 @@ bool VerifySignature(const CTransaction& txFrom, const CTransaction& txTo, unsig
     if (txin.prevout.hash != txFrom.GetHash())
         return false;
 
+    if (txin.fChecked)
+      {
+        if (fDebug)
+          printf ("VerifySignature: skipped cached verification for %s/%u\n",
+                  txTo.GetHash ().ToString ().substr (0, 10).c_str (), nIn);
+        return true;
+      }
+
     if (!VerifyScript(txin.scriptSig, txout.scriptPubKey, txTo, nIn, nHashType))
         return false;
 
+    txin.fChecked = true;
     return true;
 }
 


### PR DESCRIPTION
Remember in each CTransaction instance when all signatures have been
verified.  This helps to speed up mining block creation, see also
https://github.com/namecoin/namecoin/issues/154.

Please double-check the code to ensure that I didn't create a "coin stealing" vulnerability or something.
