### PR TITLE
Add more aggressive caching of previous txouts in CTxIn.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -207,6 +207,7 @@ bool AppInit2(int argc, char* argv[])
 
     fDebug = GetBoolArg("-debug");
     fAllowDNS = GetBoolArg("-dns");
+    fCacheTxPrev = !GetBoolArg ("-notxprevcache");
 
 #if !defined(WIN32) && !defined(QT_GUI)
     fDaemon = GetBoolArg("-daemon");
@@ -644,6 +645,7 @@ std::string HelpMessage()
         "  -daemon          \t\t  " + _("Run in the background as a daemon and accept commands\n") +
 #endif
         "  -testnet         \t\t  " + _("Use the test network\n") +
+        "  -notxprevcache   \t\t  " + _("Cache previous transactions for performance\n") +
         "  -rpcuser=<user>  \t  "   + _("Username for JSON-RPC connections\n") +
         "  -rpcpassword=<pw>\t  "   + _("Password for JSON-RPC connections\n") +
         "  -rpcport=<port>  \t\t  " + _("Listen for JSON-RPC connections on <port> (default: 8336)\n") +

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -223,13 +223,20 @@ CTxIn::~CTxIn ()
   ClearCache ();
 }
 
-void
+bool
 CTxIn::ClearCache () const
 {
+  bool cleared = false;
   if (txPrev)
-    delete txPrev;
+    {
+      delete txPrev;
+      cleared = true;
+    }
+
   txPrev = NULL;
   prevHeight = -1;
+  
+  return cleared;
 }
 
 CTxIn&

--- a/src/main.h
+++ b/src/main.h
@@ -304,9 +304,13 @@ public:
     unsigned int nSequence;
 
     /* In memory only:  Cache information about prevout and signature
-       verifications, so that we can avoid extra CPU load and disk accesses.  */
+       verifications, so that we can avoid extra CPU load and disk accesses.
+       We may also remember the previous tx's height (if it is deep enough
+       in the chain so that we assume no reorgs happen).  It is -1 if we
+       don't cache it.  */
     mutable const CTransaction* txPrev;
     mutable CDiskTxPos prevPos;
+    mutable int prevHeight;
     mutable bool fChecked;
 
     inline CTxIn ()

--- a/src/main.h
+++ b/src/main.h
@@ -348,7 +348,7 @@ public:
           ClearCache ();
     )
     
-    void ClearCache () const;
+    bool ClearCache () const;
 
     bool IsFinal() const
     {

--- a/src/main.h
+++ b/src/main.h
@@ -306,6 +306,7 @@ public:
     /* In memory only:  Cache information about prevout and signature
        verifications, so that we can avoid extra CPU load and disk accesses.  */
     mutable const CTransaction* txPrev;
+    mutable CDiskTxPos prevPos;
     mutable bool fChecked;
 
     inline CTxIn ()
@@ -340,8 +341,10 @@ public:
         READWRITE(nSequence);
 
         if (fRead)
-          txPrev = NULL;
+          ClearCache ();
     )
+    
+    void ClearCache () const;
 
     bool IsFinal() const
     {
@@ -890,9 +893,14 @@ public:
         return !(a == b);
     }
 
-    const CBlockIndex* GetContainingBlock () const;
-    int GetHeight () const;
-    int GetDepthInMainChain () const;
+    static const CBlockIndex* GetContainingBlock (const CDiskTxPos& pos);
+    static int GetHeight (const CDiskTxPos& pos);
+    static int GetDepthInMainChain (const CDiskTxPos& pos);
+
+    inline int GetDepthInMainChain () const
+    {
+      return GetDepthInMainChain (pos);
+    }
 };
 
 

--- a/src/main.h
+++ b/src/main.h
@@ -878,7 +878,10 @@ public:
     {
         return !(a == b);
     }
-    int GetDepthInMainChain() const;
+
+    const CBlockIndex* GetContainingBlock () const;
+    int GetHeight () const;
+    int GetDepthInMainChain () const;
 };
 
 

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1292,7 +1292,7 @@ bool VerifySignature(const CTransaction& txFrom, const CTransaction& txTo, unsig
     if (txin.prevout.hash != txFrom.GetHash())
         return false;
 
-    if (txin.fChecked)
+    if (txin.txPrev && txin.fChecked)
       {
         if (fDebug)
           printf ("VerifySignature: skipped cached verification for %s/%u\n",
@@ -1303,7 +1303,13 @@ bool VerifySignature(const CTransaction& txFrom, const CTransaction& txTo, unsig
     if (!VerifyScript(txin.scriptSig, txout.scriptPubKey, txTo, nIn, nHashType))
         return false;
 
-    txin.fChecked = true;
+    /* If we are caching, remember the successful verification.  */
+    if (txin.txPrev)
+      {
+        assert (*txin.txPrev == txFrom);
+        txin.fChecked = true;
+      }
+
     return true;
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -29,6 +29,7 @@ string strMiscWarning;
 bool fTestNet = false;
 bool fNoListen = false;
 bool fLogTimestamps = false;
+bool fCacheTxPrev = true;
 
 
 

--- a/src/util.h
+++ b/src/util.h
@@ -207,6 +207,7 @@ extern std::string strMiscWarning;
 extern bool fTestNet;
 extern bool fNoListen;
 extern bool fLogTimestamps;
+extern bool fCacheTxPrev;
 
 void RandAddSeed();
 void RandAddSeedPerfmon();


### PR DESCRIPTION
Cache previous txouts matching a CTxIn when they have been loaded from disk.  Also cache their height when it has been determined for CreateNewBlock.  This should speed CreateNewBlock (and thus getwork/getauxblock) up considerably for large numbers of inputs processed in a block.  Please review the code carefully to ensure I've not introduced any bugs, and test that all mining related things still work fine.  I've only done some casual testing that getwork and getauxblock still run fine, but can't really judge whether everything is fully correct.
