### PR TITLE
Add "mild" caching for priority calculation.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -207,7 +207,7 @@ bool AppInit2(int argc, char* argv[])
 
     fDebug = GetBoolArg("-debug");
     fAllowDNS = GetBoolArg("-dns");
-    fCacheTxPrev = !GetBoolArg ("-notxprevcache");
+    fCacheTxPrev = GetBoolArg ("-txprevcache");
 
 #if !defined(WIN32) && !defined(QT_GUI)
     fDaemon = GetBoolArg("-daemon");
@@ -645,7 +645,7 @@ std::string HelpMessage()
         "  -daemon          \t\t  " + _("Run in the background as a daemon and accept commands\n") +
 #endif
         "  -testnet         \t\t  " + _("Use the test network\n") +
-        "  -notxprevcache   \t\t  " + _("Disable caching of previous transactions (less RAM, more CPU)\n") +
+        "  -txprevcache   \t\t  "   + _("Enable caching of previous transactions (more RAM, less disk access)\n") +
         "  -rpcuser=<user>  \t  "   + _("Username for JSON-RPC connections\n") +
         "  -rpcpassword=<pw>\t  "   + _("Password for JSON-RPC connections\n") +
         "  -rpcport=<port>  \t\t  " + _("Listen for JSON-RPC connections on <port> (default: 8336)\n") +

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1136,14 +1136,16 @@ CTransaction::ConnectInputs (DatabaseSet& dbset,
                 else
                   txPrev = newTxPrev.get ();
 
-                if (vin[i].fHasPrevInfo)
-                  assert (vin[i].prevPos == txindex.pos);
-                else
+                /* If we didn't have any cache info, add it and
+                   set signature check to false.  We update the
+                   prevPos in any case, because it changes when a
+                   transaction gets confirmed out of the mempool.  */
+                if (!vin[i].fHasPrevInfo)
                   {
                     vin[i].fHasPrevInfo = true;
-                    vin[i].prevPos = txindex.pos;
                     vin[i].fChecked = false;
                   }
+                vin[i].prevPos = txindex.pos;
               }
             else
               {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -630,7 +630,7 @@ bool CWalletTx::AcceptWalletTransaction()
 const CBlockIndex*
 CTxIndex::GetContainingBlock (const CDiskTxPos& pos)
 {
-    if (pos == CDiskTxPos(1, 1, 1))
+    if (pos.IsNull () || pos == CDiskTxPos(1, 1, 1))
       return NULL;
 
     // Read block header

--- a/src/main.h
+++ b/src/main.h
@@ -309,16 +309,18 @@ public:
        in the chain so that we assume no reorgs happen).  It is -1 if we
        don't cache it.  */
     mutable const CTransaction* txPrev;
+    mutable bool fHasPrevInfo;
     mutable CDiskTxPos prevPos;
+    mutable int64 nValue;
     mutable int prevHeight;
     mutable bool fChecked;
 
     inline CTxIn ()
-      : nSequence(UINT_MAX), txPrev(NULL)
+      : nSequence(UINT_MAX), txPrev(NULL), fHasPrevInfo(false)
     {}
 
     inline CTxIn (const CTxIn& in)
-      : txPrev(NULL)
+      : txPrev(NULL), fHasPrevInfo(false)
     {
       operator= (in);
     }
@@ -326,14 +328,14 @@ public:
     explicit inline CTxIn (COutPoint prevoutIn, CScript scriptSigIn = CScript(),
                            unsigned int nSequenceIn = UINT_MAX)
       : prevout(prevoutIn), scriptSig(scriptSigIn), nSequence(nSequenceIn),
-        txPrev(NULL)
+        txPrev(NULL), fHasPrevInfo(false)
     {}
 
     inline CTxIn (uint256 hashPrevTx, unsigned int nOut,
                   CScript scriptSigIn = CScript(),
                   unsigned int nSequenceIn = UINT_MAX)
       : prevout(hashPrevTx, nOut), scriptSig(scriptSigIn),
-        nSequence(nSequenceIn), txPrev(NULL)
+        nSequence(nSequenceIn), txPrev(NULL), fHasPrevInfo(false)
     {}
 
     ~CTxIn ();
@@ -345,10 +347,11 @@ public:
         READWRITE(nSequence);
 
         if (fRead)
-          ClearCache ();
+          InvalidateCache ();
     )
 
     bool ClearCache () const;
+    void InvalidateCache () const;
 
     bool IsFinal() const
     {

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1292,7 +1292,7 @@ bool VerifySignature(const CTransaction& txFrom, const CTransaction& txTo, unsig
     if (txin.prevout.hash != txFrom.GetHash())
         return false;
 
-    if (txin.txPrev && txin.fChecked)
+    if (txin.fHasPrevInfo && txin.fChecked)
       {
         if (fDebug)
           printf ("VerifySignature: skipped cached verification for %s/%u\n",
@@ -1304,9 +1304,12 @@ bool VerifySignature(const CTransaction& txFrom, const CTransaction& txTo, unsig
         return false;
 
     /* If we are caching, remember the successful verification.  */
-    if (txin.txPrev)
+    if (txin.fHasPrevInfo)
       {
-        assert (*txin.txPrev == txFrom);
+#ifndef NDEBUG
+        if (txin.txPrev)
+          assert (*txin.txPrev == txFrom);
+#endif // NDEBUG?
         txin.fChecked = true;
       }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -29,7 +29,7 @@ string strMiscWarning;
 bool fTestNet = false;
 bool fNoListen = false;
 bool fLogTimestamps = false;
-bool fCacheTxPrev = true;
+bool fCacheTxPrev = false;
 
 
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -566,9 +566,11 @@ void CWallet::ReacceptWalletTransactions()
             }
             else
             {
-                // Reaccept any txes of ours that aren't already in a block
+                /* Reaccept any txes of ours that aren't already in a block.
+                   We have to check the inputs to make sure that the
+                   prev tx cache is filled properly.  */
                 if (!wtx.IsCoinBase())
-                  wtx.AcceptWalletTransaction (dbset, false);
+                  wtx.AcceptWalletTransaction (dbset);
             }
         }
         if (hasMissingTx)


### PR DESCRIPTION
Enable priority calculation without loading the prev tx from disk using only a "mild" variant of txprev caching.  This is always enabled, independently of -txprevcache.  The amount of memory used per tx input in the mempool is only increased by a flat amount of bytes (not a full transaction in memory as with -txprevcache).

This also disables the txprev cache by default, and changes the option from "-notxprevcache" to "-txprevcache" for that.
