### PR TITLE
Re-enable "getheaders" network command.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2654,11 +2654,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
 
     else if (strCommand == "getheaders")
     {
-        /* 'getheaders' is never sent by the client code and thus also
-           not well tested.  Disable it for this reason until it is actually
-           used by some clients in production.  */
-        printf ("warning: ignored 'getheaders' message\n");
-#if 0
         CBlockLocator locator;
         uint256 hashStop;
         vRecv >> locator >> hashStop;
@@ -2691,7 +2686,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         }
 
         pfrom->PushMessage("headers", vHeaders);
-#endif
     }
 
 

--- a/src/main.h
+++ b/src/main.h
@@ -1237,25 +1237,18 @@ public:
         nNonce         = block.nNonce;
     }
 
-    /* GetBlockHeader is never actually used in the code, thus disable
-       it since it can't reliably be tested.  It can be re-enabled
-       when necessary later.  */
-#if 0
     CBlock GetBlockHeader() const
     {
         CBlock block;
+        if (!block.ReadFromDisk (nFile, nBlockPos, false))
+          throw std::runtime_error ("CBlock::ReadFromDisk failed while"
+                                    " retrieving auxpow");
 
-        /* If this block has auxpow but it is not yet loaded, do this
-           now and keep it in memory.  */
-        if (hasAuxpow && !auxpow)
-          {
-            printf ("GetBlockHeader(): reading auxpow from disk");
-            if (!block.ReadFromDisk (nFile, nBlockPos, false))
-              throw std::runtime_error ("CBlock::ReadFromDisk failed while"
-                                        " retrieving auxpow");
-            auxpow = block.auxpow;
-            return block;
-          }
+        return block;
+
+/*
+Always load the block from disk, since it may contain
+an auxpow which is not part of the memory-data we have.
 
         block.nVersion       = nVersion;
         if (pprev)
@@ -1268,8 +1261,8 @@ public:
         assert ((hasAuxpow && block.auxpow) || (!hasAuxpow && !block.auxpow));
 
         return block;
+*/
     }
-#endif
 
     uint256 GetBlockHash() const
     {


### PR DESCRIPTION
This patch enables the `getheaders` network command again.  It was disabled when removing auxpow from `CBlockIndex` objects, but can be implemented by loading the block from disk.  This is better than not providing the command at all, but not yet a very "optimised" implementation.
