### PR TITLE
fix compilation issue

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -110,7 +110,7 @@ obj/test/%.o: test/%.cpp $(HEADERS)
 obj/nogui/namecoin.o: namecoin.h
 
 namecoind: $(OBJS:obj/%=obj/nogui/%) obj/nogui/namecoin.o
-	$(CXX) $(CXXFLAGS) -o $@ $(LIBPATHS) $^ $(LIBS)
+	$(CXX) $(CXXFLAGS) -o $@ $(LIBPATHS) $^ $(LIBS) -lrt
 
 clean:
 	-rm -f namecoin namecoind


### PR DESCRIPTION
I had issue with compilation of namecoin on Ubuntu12.04 with libboost 1.53 installed
Terminal looked like this:

```
~/coins/daemons/namecoin_2014-10-28_20-10/src$ make namecoind USE_UPNP=
g++ -c -O2 -Wno-invalid-offsetof -Wformat -D_MT -DNOPCH -DFOURWAYSSE2 -DUSE_SSL -DBOOST_THREAD_USE_LIB -I../libs/openssl-1.0.1i/include -I../libs/db-4.7.25.NC/build_unix -I../libs/boost_1_50_0 -o obj/nogui/auxpow.o auxpow.cpp
g++ -c -O2 -Wno-invalid-offsetof -Wformat -D_MT -DNOPCH -DFOURWAYSSE2 -DUSE_SSL -DBOOST_THREAD_USE_LIB -I../libs/openssl-1.0.1i/include -I../libs/db-4.7.25.NC/build_unix -I../libs/boost_1_50_0 -o obj/nogui/util.o util.cpp
g++ -c -O2 -Wno-invalid-offsetof -Wformat -D_MT -DNOPCH -DFOURWAYSSE2 -DUSE_SSL -DBOOST_THREAD_USE_LIB -I../libs/openssl-1.0.1i/include -I../libs/db-4.7.25.NC/build_unix -I../libs/boost_1_50_0 -o obj/nogui/key.o key.cpp
g++ -c -O2 -Wno-invalid-offsetof -Wformat -D_MT -DNOPCH -DFOURWAYSSE2 -DUSE_SSL -DBOOST_THREAD_USE_LIB -I../libs/openssl-1.0.1i/include -I../libs/db-4.7.25.NC/build_unix -I../libs/boost_1_50_0 -o obj/nogui/script.o script.cpp
g++ -c -O2 -Wno-invalid-offsetof -Wformat -D_MT -DNOPCH -DFOURWAYSSE2 -DUSE_SSL -DBOOST_THREAD_USE_LIB -I../libs/openssl-1.0.1i/include -I../libs/db-4.7.25.NC/build_unix -I../libs/boost_1_50_0 -o obj/nogui/db.o db.cpp
g++ -c -O2 -Wno-invalid-offsetof -Wformat -D_MT -DNOPCH -DFOURWAYSSE2 -DUSE_SSL -DBOOST_THREAD_USE_LIB -I../libs/openssl-1.0.1i/include -I../libs/db-4.7.25.NC/build_unix -I../libs/boost_1_50_0 -o obj/nogui/walletdb.o walletdb.cpp
g++ -c -O2 -Wno-invalid-offsetof -Wformat -D_MT -DNOPCH -DFOURWAYSSE2 -DUSE_SSL -DBOOST_THREAD_USE_LIB -I../libs/openssl-1.0.1i/include -I../libs/db-4.7.25.NC/build_unix -I../libs/boost_1_50_0 -o obj/nogui/crypter.o crypter.cpp
g++ -c -O2 -Wno-invalid-offsetof -Wformat -D_MT -DNOPCH -DFOURWAYSSE2 -DUSE_SSL -DBOOST_THREAD_USE_LIB -I../libs/openssl-1.0.1i/include -I../libs/db-4.7.25.NC/build_unix -I../libs/boost_1_50_0 -o obj/nogui/net.o net.cpp
g++ -c -O2 -Wno-invalid-offsetof -Wformat -D_MT -DNOPCH -DFOURWAYSSE2 -DUSE_SSL -DBOOST_THREAD_USE_LIB -I../libs/openssl-1.0.1i/include -I../libs/db-4.7.25.NC/build_unix -I../libs/boost_1_50_0 -o obj/nogui/irc.o irc.cpp
g++ -c -O2 -Wno-invalid-offsetof -Wformat -D_MT -DNOPCH -DFOURWAYSSE2 -DUSE_SSL -DBOOST_THREAD_USE_LIB -I../libs/openssl-1.0.1i/include -I../libs/db-4.7.25.NC/build_unix -I../libs/boost_1_50_0 -o obj/nogui/keystore.o keystore.cpp
g++ -c -O2 -Wno-invalid-offsetof -Wformat -D_MT -DNOPCH -DFOURWAYSSE2 -DUSE_SSL -DBOOST_THREAD_USE_LIB -I../libs/openssl-1.0.1i/include -I../libs/db-4.7.25.NC/build_unix -I../libs/boost_1_50_0 -o obj/nogui/main.o main.cpp
g++ -c -O2 -Wno-invalid-offsetof -Wformat -D_MT -DNOPCH -DFOURWAYSSE2 -DUSE_SSL -DBOOST_THREAD_USE_LIB -I../libs/openssl-1.0.1i/include -I../libs/db-4.7.25.NC/build_unix -I../libs/boost_1_50_0 -o obj/nogui/wallet.o wallet.cpp
g++ -c -O2 -Wno-invalid-offsetof -Wformat -D_MT -DNOPCH -DFOURWAYSSE2 -DUSE_SSL -DBOOST_THREAD_USE_LIB -I../libs/openssl-1.0.1i/include -I../libs/db-4.7.25.NC/build_unix -I../libs/boost_1_50_0 -o obj/nogui/bitcoinrpc.o bitcoinrpc.cpp
g++ -c -O2 -Wno-invalid-offsetof -Wformat -D_MT -DNOPCH -DFOURWAYSSE2 -DUSE_SSL -DBOOST_THREAD_USE_LIB -I../libs/openssl-1.0.1i/include -I../libs/db-4.7.25.NC/build_unix -I../libs/boost_1_50_0 -o obj/nogui/init.o init.cpp
g++ -c -O2 -Wno-invalid-offsetof -Wformat -D_MT -DNOPCH -DFOURWAYSSE2 -DUSE_SSL -DBOOST_THREAD_USE_LIB -I../libs/openssl-1.0.1i/include -I../libs/db-4.7.25.NC/build_unix -I../libs/boost_1_50_0 -O3 -o cryptopp/obj/sha.o cryptopp/sha.cpp
g++ -c -O2 -Wno-invalid-offsetof -Wformat -D_MT -DNOPCH -DFOURWAYSSE2 -DUSE_SSL -DBOOST_THREAD_USE_LIB -I../libs/openssl-1.0.1i/include -I../libs/db-4.7.25.NC/build_unix -I../libs/boost_1_50_0 -O3 -o cryptopp/obj/cpu.o cryptopp/cpu.cpp
g++ -c -O2 -Wno-invalid-offsetof -Wformat -D_MT -DNOPCH -DFOURWAYSSE2 -DUSE_SSL -DBOOST_THREAD_USE_LIB -I../libs/openssl-1.0.1i/include -I../libs/db-4.7.25.NC/build_unix -I../libs/boost_1_50_0 -o obj/nogui/namecoin.o namecoin.cpp
g++ -O2 -Wno-invalid-offsetof -Wformat -D_MT -DNOPCH -DFOURWAYSSE2 -DUSE_SSL -DBOOST_THREAD_USE_LIB -I../libs/openssl-1.0.1i/include -I../libs/db-4.7.25.NC/build_unix -I../libs/boost_1_50_0 -o namecoind -L../libs/openssl-1.0.1i -L../libs/db-4.7.25.NC/build_unix -L../libs/boost_1_50_0/stage/lib obj/nogui/auxpow.o obj/nogui/util.o obj/nogui/key.o obj/nogui/script.o obj/nogui/db.o obj/nogui/walletdb.o obj/nogui/crypter.o obj/nogui/net.o obj/nogui/irc.o obj/nogui/keystore.o obj/nogui/main.o obj/nogui/wallet.o obj/nogui/bitcoinrpc.o obj/nogui/init.o cryptopp/obj/sha.o cryptopp/obj/cpu.o obj/nogui/namecoin.o -Wl,-Bstatic -l boost_system -l boost_filesystem -l boost_program_options -l boost_thread -l boost_chrono -l db_cxx -l ssl -l crypto -Wl,-Bdynamic -l gthread-2.0 -l z -l dl -l pthread -Wl,-Bdynamic -l gthread-2.0 -l z -l dl -l pthread
/usr/lib/gcc/x86_64-linux-gnu/4.6/../../../../lib/libboost_thread.a(thread.o): In function `boost::this_thread::hiden::sleep_until(timespec const&)':
(.text+0x1660): undefined reference to `clock_gettime'
/usr/lib/gcc/x86_64-linux-gnu/4.6/../../../../lib/libboost_thread.a(thread.o): In function `boost::this_thread::hiden::sleep_until(timespec const&)':
(.text+0x16d1): undefined reference to `clock_gettime'
/usr/lib/gcc/x86_64-linux-gnu/4.6/../../../../lib/libboost_thread.a(thread.o): In function `boost::this_thread::hiden::sleep_until(timespec const&)':
(.text+0x173c): undefined reference to `clock_gettime'
/usr/lib/gcc/x86_64-linux-gnu/4.6/../../../../lib/libboost_thread.a(thread.o): In function `boost::this_thread::hiden::sleep_until(timespec const&)':
(.text+0x17a7): undefined reference to `clock_gettime'
/usr/lib/gcc/x86_64-linux-gnu/4.6/../../../../lib/libboost_thread.a(thread.o): In function `boost::this_thread::hiden::sleep_until(timespec const&)':
(.text+0x1812): undefined reference to `clock_gettime'
/usr/lib/gcc/x86_64-linux-gnu/4.6/../../../../lib/libboost_thread.a(thread.o):(.text+0x187d): more undefined references to `clock_gettime' follow
collect2: ld returned 1 exit status
make: *** [namecoind] Error 1
```

I fixed Makefile based on information from these discussions and then namecoin compiled successfully:
- http://seqanswers.com/forums/showthread.php?t=28225
- http://stackoverflow.com/questions/8301600/how-to-set-library-search-path-for-64-bit-libraries-for-g-in-ubuntu
