### PR TITLE
Disallow auxpow parent blocks that have auxpow themselves.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1633,6 +1633,14 @@ bool CBlock::CheckProofOfWork(int nHeight) const
 
         if (auxpow.get() != NULL)
         {
+            /* Disallow auxpow parent blocks that have an auxpow themselves.  */
+            if (nHeight >= FORK_HEIGHT_STRICTCHECKS
+                && (auxpow->parentBlock.nVersion & BLOCK_VERSION_AUXPOW))
+              return error("%s : auxpow parent block has auxpow version",
+                           __func__);
+            assert(nHeight < FORK_HEIGHT_STRICTCHECKS
+                    || !auxpow->parentBlock.auxpow);
+
             if (!auxpow->Check(GetHash(), GetChainID()))
                 return error("CheckProofOfWork() : AUX POW is not valid");
             // Check proof of work matches claimed amount
@@ -3539,6 +3547,11 @@ bool CheckWork(CBlock* pblock, CWallet& wallet, CReserveKey& reservekey)
 
     if (auxpow != NULL)
     {
+        /* Disallow auxpow parent blocks that have an auxpow themselves.  */
+        if (auxpow->parentBlock.nVersion & BLOCK_VERSION_AUXPOW)
+            return error("%s : auxpow parent block has auxpow version",
+                         __func__);
+
         if (!auxpow->Check(hash, pblock->GetChainID()))
             return error("AUX POW is not valid");
 

--- a/src/main.h
+++ b/src/main.h
@@ -59,6 +59,11 @@ static const int COINBASE_MATURITY = 100;
 // -paytxfee default
 static const int64 DEFAULT_TRANSACTION_FEE = MIN_TX_FEE;
 
+/* Height of the softfork disallowing certain "buggy" constructions.  This is
+   in preparation of the switch to the rebased client at some point later
+   in the future.  */
+static const int FORK_HEIGHT_STRICTCHECKS = 300000;
+
 #ifdef USE_UPNP
 static const int fHaveUPnP = true;
 #else


### PR DESCRIPTION
Currently, auxpow parent blocks may contain an auxpow field themselves.  This allows (in theory) for arbitrarily large auxpow's.  While this is mostly a theoretical problem, it should be fixed eventually.  This patch makes namecoind reject auxpow parent blocks that have an auxpow themselves in a softfork (the height needs to be determined).
