### PR TITLE
Remove the mandatory "per-dust-output" fee rule.

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -629,6 +629,8 @@ public:
         return dPriority > COIN * 144 / 250;
     }
 
+    /* Get minimum fee to enforce (fForRelay = true) or to attach to tx created
+       (fForRelay = false).  */
     int64 GetMinFee(unsigned int nBlockSize=1, bool fAllowFree=true, bool fForRelay=false) const
     {
         // Base fee is either MIN_TX_FEE or MIN_RELAY_TX_FEE
@@ -654,10 +656,15 @@ public:
             }
         }
 
-        // To limit dust spam, require MIN_TX_FEE/MIN_RELAY_TX_FEE for any output less than 0.01
-        BOOST_FOREACH(const CTxOut& txout, vout)
+        /* The old rule was to require a "base fee" for any output less than
+           0.01 NMC.  This rule is no longer enforced (instead, we disallow
+           spam outputs right away in AcceptToMemoryPool similarly to
+           what Bitcoin does).  When creating the tx, still attach the
+           fee because we want the tx to be relayed by old clients as well.  */
+        if (!fForRelay)
+          BOOST_FOREACH(const CTxOut& txout, vout)
             if (txout.nValue < CENT)
-                nMinFee += nBaseFee;
+              nMinFee += nBaseFee;
 
         // Raise the price as the block approaches full
         if (nBlockSize != 1 && nNewBlockSize >= MAX_BLOCK_SIZE_GEN/2)


### PR DESCRIPTION
Instead, enforce a rule similar to Bitcoin:  Completely disallow (no matter what fee) outputs less than 0.0001 NMC.

This helps to harmonise fee rules between Namecoin and what is common in Bitcoin, which simplifies development of things like the Armory port.  (No special rules required for Namecoin.)  Dust spam as it appeared historically (and was prevented by the now-removed rule) should be avoided by the dust output rule just as well.
