### PR TITLE
Clean up name_new.

### DIFF
--- a/src/hook.h
+++ b/src/hook.h
@@ -33,7 +33,7 @@ public:
     virtual int LockinHeight() = 0;
     virtual std::string IrcPrefix() = 0;
     virtual void MessageStart(char* pchMessageStart) = 0;
-    virtual void AcceptToMemoryPool(DatabaseSet& dbset, const CTransaction& tx) = 0;
+    virtual bool AcceptToMemoryPool(DatabaseSet& dbset, const CTransaction& tx) = 0;
     virtual void RemoveFromMemoryPool(const CTransaction& tx) = 0;
 
     /* These are for display and wallet management purposes.  Not for use to decide

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -509,13 +509,14 @@ CTransaction::AcceptToMemoryPool (DatabaseSet& dbset, bool fCheckInputs,
         }
     }
 
+    if (!hooks->AcceptToMemoryPool (dbset, *this))
+      return error ("AcceptToMemoryPool: hook failed");
+
     // Store transaction in memory
     CRITICAL_BLOCK(cs_mapTransactions)
     {
         AddToMemoryPoolUnchecked();
     }
-
-    hooks->AcceptToMemoryPool (dbset, *this);
 
     printf("AcceptToMemoryPool(): accepted %s\n", hash.ToString().substr(0,10).c_str());
     return true;

--- a/src/namecoin.cpp
+++ b/src/namecoin.cpp
@@ -28,10 +28,6 @@ template<typename T> void ConvertTo(Value& value, bool fAllowNull=false);
 static const int BUG_WORKAROUND_BLOCK_START = 139750;   // Bug was not exploited before block 139872, so skip checking earlier blocks
 static const int BUG_WORKAROUND_BLOCK = 150000;         // Point of hard fork
 
-/* Disallow transactions without NAMECOIN_TX_VERSION but with name outputs
-   after this height.  */
-static const int FORK_HEIGHT_TXVERSION = 300000;
-
 std::map<vchType, uint256> mapMyNames;
 std::map<vchType, set<uint256> > mapNamePending;
 std::set<vchType> setNewHashes;
@@ -2232,7 +2228,7 @@ CNamecoinHooks::ConnectInputs (DatabaseSet& dbset,
         }
 
         if (foundOuts
-            && (!fBlock || pindexBlock->nHeight >= FORK_HEIGHT_TXVERSION))
+            && (!fBlock || pindexBlock->nHeight >= FORK_HEIGHT_STRICTCHECKS))
             return error("ConnectInputHook: non-Namecoin tx has name outputs");
 
         // Make sure name-op outputs are not spent by a regular transaction, or the name

--- a/src/namecoin.h
+++ b/src/namecoin.h
@@ -27,6 +27,7 @@ class uint256;
 
 extern std::map<vchType, uint256> mapMyNames;
 extern std::map<vchType, std::set<uint256> > mapNamePending;
+extern std::set<vchType> setNewHashes;
 
 std::string stringFromVch(const std::vector<unsigned char> &vch);
 std::vector<unsigned char> vchFromString(const std::string &str);


### PR DESCRIPTION
Clean up the code corresponding to name_new, propagate failure to accept a tx to mempool from Namecoin hooks to the core, and remove `FORK_HEIGHT_TXVERSION` (use the common `FORK_HEIGHT_STRICTCHECKS` of the upcoming softfork).
