### PR TITLE
Set fork height and bump version.

### DIFF
--- a/namecoin-qt.pro
+++ b/namecoin-qt.pro
@@ -1,7 +1,7 @@
 TEMPLATE = app
 TARGET = namecoin-qt
 macx:TARGET = "Namecoin-Qt"
-VERSION = 0.3.76rc1
+VERSION = 0.3.80
 INCLUDEPATH += src src/json src/qt
 QT += core gui network
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1649,12 +1649,11 @@ bool CBlock::CheckProofOfWork(int nHeight) const
         if (auxpow.get() != NULL)
         {
             /* Disallow auxpow parent blocks that have an auxpow themselves.  */
-            if (nHeight >= FORK_HEIGHT_STRICTCHECKS
+            if (doStrictChecks (nHeight)
                 && (auxpow->parentBlock.nVersion & BLOCK_VERSION_AUXPOW))
               return error("%s : auxpow parent block has auxpow version",
                            __func__);
-            assert(nHeight < FORK_HEIGHT_STRICTCHECKS
-                    || !auxpow->parentBlock.auxpow);
+            assert(!doStrictChecks (nHeight) || !auxpow->parentBlock.auxpow);
 
             if (!auxpow->Check(GetHash(), GetChainID()))
                 return error("CheckProofOfWork() : AUX POW is not valid");
@@ -1732,7 +1731,7 @@ bool CBlock::CheckBlock(int nHeight) const
         return error("CheckBlock() : size limits failed");
 
     // Enforce DB lock limit.
-    if (nHeight >= FORK_HEIGHT_STRICTCHECKS && !CheckDbLockLimit(*this))
+    if (doStrictChecks (nHeight) && !CheckDbLockLimit(*this))
         return error("%s : DB lock limit exceeded", __func__);
 
     if (!CheckProofOfWork(nHeight))

--- a/src/main.h
+++ b/src/main.h
@@ -59,11 +59,6 @@ static const int COINBASE_MATURITY = 100;
 // -paytxfee default
 static const int64 DEFAULT_TRANSACTION_FEE = MIN_TX_FEE;
 
-/* Height of the softfork disallowing certain "buggy" constructions.  This is
-   in preparation of the switch to the rebased client at some point later
-   in the future.  */
-static const int FORK_HEIGHT_STRICTCHECKS = 300000;
-
 #ifdef USE_UPNP
 static const int fHaveUPnP = true;
 #else

--- a/src/namecoin.cpp
+++ b/src/namecoin.cpp
@@ -25,7 +25,6 @@ extern int64 AmountFromValue(const Value& value);
 extern Object JSONRPCError(int code, const string& message);
 template<typename T> void ConvertTo(Value& value, bool fAllowNull=false);
 
-static const int BUG_WORKAROUND_BLOCK_START = 139750;   // Bug was not exploited before block 139872, so skip checking earlier blocks
 static const int BUG_WORKAROUND_BLOCK = 150000;         // Point of hard fork
 
 std::map<vchType, uint256> mapMyNames;
@@ -114,6 +113,19 @@ public:
         return "04fc4366270096c7e40adb8c3fcfbff12335f3079e5e7905bce6b1539614ae057ee1e61a25abdae4a7a2368505db3541cd81636af3f7c7afe8591ebc85b2a1acdd";
     }
 };
+
+/**
+ * Check whether the given height is post-libcoin-hardfork.  I. e.,
+ * strict checks for name_update and tx decoding should be applied.
+ */
+static bool
+postLibcoinFork(unsigned nHeight)
+{
+  if (fTestNet)
+    return nHeight >= 108000;
+
+  return nHeight >= BUG_WORKAROUND_BLOCK;
+}
 
 int64 getAmount(Value value)
 {
@@ -1734,7 +1746,7 @@ bool CNameDB::ReconstructNameIndex()
 
                 // Bug workaround
                 CDiskTxPos prevTxPos;
-                if (nHeight >= BUG_WORKAROUND_BLOCK_START && nHeight < BUG_WORKAROUND_BLOCK)
+                if (!postLibcoinFork (nHeight))
                     if (!NameBugWorkaround(tx, txdb, &prevTxPos))
                     {
                         printf("NameBugWorkaround rejected tx %s at height %d (name %s)\n", tx.GetHash().ToString().c_str(), nHeight, stringFromVch(vchName).c_str());
@@ -1748,7 +1760,8 @@ bool CNameDB::ReconstructNameIndex()
                         return error("Rescanfornames() : failed to read from name DB");
                 }
 
-                if (op == OP_NAME_UPDATE && nHeight >= BUG_WORKAROUND_BLOCK_START && nHeight < BUG_WORKAROUND_BLOCK && !CheckNameTxPos(vtxPos, prevTxPos))
+                if (op == OP_NAME_UPDATE && !postLibcoinFork (nHeight)
+                    && !CheckNameTxPos(vtxPos, prevTxPos))
                 {
                     printf("NameBugWorkaround rejected tx %s at height %d (name %s), because previous tx was also rejected\n", tx.GetHash().ToString().c_str(), nHeight, stringFromVch(vchName).c_str());
                     continue;
@@ -1864,7 +1877,7 @@ bool DecodeNameTx(const CTransaction& tx, int& op, int& nOut, vector<vector<unsi
     }
 
     // Bug workaround
-    if (nHeight >= BUG_WORKAROUND_BLOCK)
+    if (postLibcoinFork (nHeight))
     {
         // Strict check - bug disallowed
         for (int i = 0; i < tx.vout.size(); i++)
@@ -2165,7 +2178,7 @@ CNamecoinHooks::ConnectInputs (DatabaseSet& dbset,
     std::vector<vchType> vvchPrevArgs;
 
     // Bug workaround
-    if (fMiner || !fBlock || pindexBlock->nHeight >= BUG_WORKAROUND_BLOCK)
+    if (fMiner || !fBlock || postLibcoinFork (pindexBlock->nHeight))
     {
         // Strict check - bug disallowed
         for (int i = 0; i < tx.vin.size(); i++)
@@ -2306,7 +2319,7 @@ CNamecoinHooks::ConnectInputs (DatabaseSet& dbset,
                 uint160 hash = Hash160(vchToHash);
                 if (uint160(vchHash) != hash)
                 {
-                    if (pindexBlock->nHeight >= BUG_WORKAROUND_BLOCK)
+                    if (postLibcoinFork (pindexBlock->nHeight))
                         return error("ConnectInputsHook() : name_firstupdate hash mismatch");
                     else
                     {
@@ -2360,7 +2373,7 @@ CNamecoinHooks::ConnectInputs (DatabaseSet& dbset,
             // Check name
             if (vvchPrevArgs[0] != vvchArgs[0])
             {
-                if (pindexBlock->nHeight >= BUG_WORKAROUND_BLOCK)
+                if (postLibcoinFork (pindexBlock->nHeight))
                     return error("ConnectInputsHook() : name_update name mismatch");
                 else
                 {
@@ -2412,7 +2425,7 @@ CNamecoinHooks::ConnectInputs (DatabaseSet& dbset,
                 {
                     printf("ConnectInputsHook() : Name bug workaround: tx %s rejected, since previous tx (%s) is not in the name DB\n", tx.GetHash().ToString().c_str(), vTxPrev[nInput].GetHash().ToString().c_str());
                     // Valid tx on top of buggy tx: reject only after hard-fork
-                    if (pindexBlock->nHeight >= BUG_WORKAROUND_BLOCK)
+                    if (postLibcoinFork (pindexBlock->nHeight))
                         return false;
                     else
                         fBugWorkaround = true;

--- a/src/namecoin.cpp
+++ b/src/namecoin.cpp
@@ -127,6 +127,19 @@ postLibcoinFork(unsigned nHeight)
   return nHeight >= BUG_WORKAROUND_BLOCK;
 }
 
+/**
+ * Check whether the given height is post the "strict checks" hardfork
+ * done in preparation for switching to the rebased client.
+ */
+bool
+doStrictChecks(unsigned nHeight)
+{
+  if (fTestNet)
+    return nHeight >= 108000;
+
+  return nHeight >= 212500;
+}
+
 int64 getAmount(Value value)
 {
     ConvertTo<double>(value);
@@ -2240,8 +2253,7 @@ CNamecoinHooks::ConnectInputs (DatabaseSet& dbset,
                 foundOuts = true;
         }
 
-        if (foundOuts
-            && (!fBlock || pindexBlock->nHeight >= FORK_HEIGHT_STRICTCHECKS))
+        if (foundOuts && (!fBlock || doStrictChecks (pindexBlock->nHeight)))
             return error("ConnectInputHook: non-Namecoin tx has name outputs");
 
         // Make sure name-op outputs are not spent by a regular transaction, or the name
@@ -2270,7 +2282,7 @@ CNamecoinHooks::ConnectInputs (DatabaseSet& dbset,
        enforce the fee, even before the fork point.  */
     if (tx.vout[nOut].nValue < MIN_AMOUNT)
       {
-        if (!fBlock || pindexBlock->nHeight >= FORK_HEIGHT_STRICTCHECKS)
+        if (!fBlock || doStrictChecks (pindexBlock->nHeight))
           return error ("ConnectInputsHook: not enough locked amount");
         printf ("WARNING: not enough locked amount, ignoring for now\n");
       }

--- a/src/namecoin.h
+++ b/src/namecoin.h
@@ -29,6 +29,8 @@ extern std::map<vchType, uint256> mapMyNames;
 extern std::map<vchType, std::set<uint256> > mapNamePending;
 extern std::set<vchType> setNewHashes;
 
+bool doStrictChecks(unsigned nHeight);
+
 std::string stringFromVch(const std::vector<unsigned char> &vch);
 std::vector<unsigned char> vchFromString(const std::string &str);
 int GetTxPosHeight(const CNameIndex& txPos);

--- a/src/qt/res/bitcoin-qt.rc
+++ b/src/qt/res/bitcoin-qt.rc
@@ -8,8 +8,8 @@ IDI_ICON1 ICON DISCARDABLE "icons/bitcoin.ico"
 
 #define CLIENT_VERSION_MAJOR 0
 #define CLIENT_VERSION_MINOR 3
-#define CLIENT_VERSION_REVISION 76
-#define CLIENT_VERSION_BUILD 1
+#define CLIENT_VERSION_REVISION 80
+#define CLIENT_VERSION_BUILD 0
 
 // Converts the parameter X to a string after macro replacement on X has been performed.
 // Don't merge these into one macro!

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -35,9 +35,9 @@ class CDataStream;
 class CAutoFile;
 static const unsigned int MAX_SIZE = 0x02000000;
 
-static const int VERSION = 37601;
+static const int VERSION = 38000;
 static const char* pszSubVer = "";
-static const bool VERSION_IS_BETA = true;
+static const bool VERSION_IS_BETA = false;
 
 
 


### PR DESCRIPTION
Bump the version to 0.3.80.  Set the fork height for the "stricter checks" softfork to 212,500 (roughly two weeks from now).  In addition, testnet is set to fork at 108,000 with both this softfork and also the one enforcing name registration rules that mainnet had at block 150,000.
