### PR TITLE
correct makefile

### DIFF
--- a/doc/build-unix.txt
+++ b/doc/build-unix.txt
@@ -15,10 +15,9 @@ To Build
 
 cd src/
 
-make -f Makefile            # Bitcoin with wxWidgets GUI
-  or
-make -f Makefile bitcoind   # Headless bitcoin
 
+make           # Namecoin with Qt GUI
+make namecoind # Headless namecoin
 
 Dependencies
 ------------

--- a/doc/build-unix.txt
+++ b/doc/build-unix.txt
@@ -15,9 +15,9 @@ To Build
 
 cd src/
 
-make -f makefile.unix            # Bitcoin with wxWidgets GUI
+make -f Makefile            # Bitcoin with wxWidgets GUI
   or
-make -f makefile.unix bitcoind   # Headless bitcoin
+make -f Makefile bitcoind   # Headless bitcoin
 
 
 Dependencies


### PR DESCRIPTION
Most coins have a makefile.unix, Namecoin does not, Do not recycle the build docs without documenting the wierd changes you make!
